### PR TITLE
Show the correct license name in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,4 +302,4 @@ Take a look at the `spec` folder before you do, and make sure `bundle exec rake 
 
 ## License
 
-Her is © 2012 [Rémi Prévost](http://exomel.com) and may be freely distributed under the [LITL license](https://github.com/remiprev/her/blob/master/LICENSE). See the `LICENSE` file.
+Her is © 2012 [Rémi Prévost](http://exomel.com) and may be freely distributed under the [MIT license](https://github.com/remiprev/her/blob/master/LICENSE). See the `LICENSE` file.


### PR DESCRIPTION
It's just a detail but it could be misleading.
