### PR TITLE
Better class name detection for paths.

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -35,8 +35,9 @@ module Her
       extend Her::Model::Paths
 
       # Define default settings
-      collection_path "/#{self.to_s.downcase.pluralize}"
-      resource_path "/#{self.to_s.downcase.pluralize}/:id"
+      base_path = self.name.split("::").last.downcase.pluralize
+      collection_path "/#{base_path}"
+      resource_path "/#{base_path}/:id"
       uses_api Her::API.default_api
     end
   end

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -3,38 +3,53 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 
 describe Her::Model::Paths do
   context "building request paths" do
-    before do # {{{
-      spawn_model :User
-    end # }}}
-
-    describe "#build_request_path" do
-      it "builds paths with defaults" do # {{{
-        User.build_request_path(id: "foo").should == "/users/foo"
-        User.build_request_path.should == "/users"
+    context "simple model" do
+      before do # {{{
+        spawn_model :User
       end # }}}
 
-      it "builds paths with custom collection path" do # {{{
-        User.collection_path "/utilisateurs"
-        User.build_request_path(id: "foo").should == "/utilisateurs/foo"
-        User.build_request_path.should == "/utilisateurs"
+      describe "#build_request_path" do
+        it "builds paths with defaults" do # {{{
+          User.build_request_path(id: "foo").should == "/users/foo"
+          User.build_request_path.should == "/users"
+        end # }}}
+
+        it "builds paths with custom collection path" do # {{{
+          User.collection_path "/utilisateurs"
+          User.build_request_path(id: "foo").should == "/utilisateurs/foo"
+          User.build_request_path.should == "/utilisateurs"
+        end # }}}
+
+        it "builds paths with custom collection path with multiple variables" do # {{{
+          User.collection_path "/organizations/:organization_id/utilisateurs"
+          User.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
+          User.build_request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
+        end # }}}
+
+        it "builds paths with custom item path" do # {{{
+          User.resource_path "/utilisateurs/:id"
+          User.build_request_path(id: "foo").should == "/utilisateurs/foo"
+          User.build_request_path.should == "/users"
+        end # }}}
+
+        it "raises exceptions when building a path without required custom variables" do # {{{
+          User.collection_path "/organizations/:organization_id/utilisateurs"
+          expect { User.build_request_path(:id => "foo") }.should raise_error(Her::Errors::PathError)
+        end # }}}
+      end
+    end
+
+    context "nested model" do
+      before do # {{{
+        spawn_submodel :Base, :User
       end # }}}
 
-      it "builds paths with custom collection path with multiple variables" do # {{{
-        User.collection_path "/organizations/:organization_id/utilisateurs"
-        User.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-        User.build_request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
-      end # }}}
-
-      it "builds paths with custom item path" do # {{{
-        User.resource_path "/utilisateurs/:id"
-        User.build_request_path(id: "foo").should == "/utilisateurs/foo"
-        User.build_request_path.should == "/users"
-      end # }}}
-
-      it "raises exceptions when building a path without required custom variables" do # {{{
-        User.collection_path "/organizations/:organization_id/utilisateurs"
-        expect { User.build_request_path(:id => "foo") }.should raise_error(Her::Errors::PathError)
-      end # }}}
+      describe "#build_request_path" do
+        it "builds paths with defaults" do # {{{
+          Base::User.build_request_path(id: "foo").should == "/users/foo"
+          Base::User.build_request_path.should == "/users"
+        end # }}}
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,13 @@ class Array
   def to_json; MultiJson.dump(self); end
 end
 
-def spawn_model(klass, attrs={}, &block)
+def spawn_model(klass, &block)
   Object.instance_eval { remove_const klass } if Object.const_defined?(klass)
   Object.const_set(klass, Class.new).send(:include, Her::Model)
   Object.const_get(klass).class_eval(&block) if block_given?
+end
+
+def spawn_submodel(mod, klass)
+  Object.instance_eval { remove_const mod } if Object.const_defined?(mod)
+  Object.const_set(mod, Module.new).const_set(klass, Class.new).send(:include, Her::Model)
 end


### PR DESCRIPTION
This allows things like:

```
module MyThing
  class User
    include Her::Model
  end
end
```

Previously, you had to specify `collection_name` manually or else you would get something like:

```
> MyThing::User.all
Her::Errors::PathError: Missing :_users parameter to build the request path (/mything::users).
from /Users/tyson/.rbenv/versions/1.9.3-p125/lib/ruby/gems/1.9.1/gems/her-0.2.1/lib/her/model/paths.rb:41:in `block in build_request_path'
```
