### PR TITLE
Fix for multi-words class names

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -35,7 +35,7 @@ module Her
       extend Her::Model::Paths
 
       # Define default settings
-      base_path = self.name.split("::").last.downcase.pluralize
+      base_path = self.name.split("::").last.underscore.pluralize
       collection_path "/#{base_path}"
       resource_path "/#{base_path}/:id"
       uses_api Her::API.default_api

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -42,7 +42,7 @@ module Her
       # @param [Hash] parsed_data The raw `parsed_data` parsed from the HTTP response
       def new_collection(parsed_data) # {{{
         collection_data = parsed_data[:data]
-        Her::Model::ORM.initialize_collection(self.to_s.downcase.to_sym, collection_data)
+        Her::Model::ORM.initialize_collection(self.to_s.underscore, collection_data)
       end # }}}
 
       # Return `true` if a resource was not saved yet


### PR DESCRIPTION
A model named ZendeskUser was converted to "zendeskuser". When building model instances, `classify` will generate "Zendeskuser" (without the uppercase "u").
The `underscore` method generates "zendesk_user", which is converted back to "ZendeskUser" by `classify`.
