### PR TITLE
Fix method missing to raise NoMethodError on the Model instead of Nil

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -20,10 +20,10 @@ module Her
       def method_missing(method, attrs=nil) # {{{
         assignment_method = method.to_s =~ /\=$/
         method = method.to_s.gsub(/(\?|\!|\=)$/, "").to_sym
-        if attrs and assignment_method
+        if @data and attrs and assignment_method
           @data[method.to_s.gsub(/\=$/, "").to_sym] = attrs
         else
-          if @data.include?(method)
+          if @data and @data.include?(method)
             @data[method]
           else
             super

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -47,6 +47,11 @@ describe Her::Model::ORM do
       @existing_user = User.find(1)
       @existing_user.new?.should be_false
     end # }}}
+
+    it "handles method missing" do# {{{
+      @new_user = User.new(:fullname => 'Mayonegg')
+      lambda { @new_user.unknown_method_for_a_user }.should raise_error(NoMethodError)
+    end# }}}
   end
 
   context "creating resources" do


### PR DESCRIPTION
Check if the instance variable data is not nil in method_missing. Before this fix, method missing was raised by the Nil::Class.
