### PR TITLE
Convert model objects into request parameters with a overrideable helper method

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -100,7 +100,7 @@ module Her
       def create(params={}) # {{{
         resource = new(params)
         wrap_in_hooks(resource, :create, :save) do |resource, klass|
-          params = resource.instance_eval { @data }
+          params = resource.to_params
           request(params.merge(:_method => :post, :_path => "#{build_request_path(params)}")) do |parsed_data|
             resource.instance_eval do
               @data = parsed_data[:data]
@@ -136,7 +136,7 @@ module Her
       #   @user.save
       #   # Called via POST "/users"
       def save # {{{
-        params = @data.dup
+        params = to_params
         resource = self
 
         if @data[:id]
@@ -184,6 +184,15 @@ module Her
         request(params.merge(:_method => :delete, :_path => "#{build_request_path(params.merge(:id => id))}")) do |parsed_data|
           new(parsed_data[:data])
         end
+      end # }}}
+
+      # Convert into a hash of request parameters
+      #
+      # @example
+      #   @user.to_params
+      #   # => { :id => 1, :name => 'John Smith' }
+      def to_params # {{{
+        @data.dup
       end # }}}
     end
   end

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -240,4 +240,39 @@ describe Her::Model::ORM do
       @user.active.should be_false
     end # }}}
   end
+
+  context "saving resources with overridden to_params" do
+    before do
+      Her::API.setup :url => "https://api.example.com" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.use Faraday::Request::UrlEncoded
+        builder.adapter :test do |stub|
+          stub.post("/users") do |env|
+            body = {
+              :id => 1,
+              :fullname => Faraday::Utils.parse_query(env[:body])['fullname']
+            }.to_json
+            [200, {}, body]
+          end
+        end
+      end
+
+      spawn_model "Foo::User" do
+        def to_params
+          { :fullname => "Lindsay Fünke" }
+        end
+      end
+    end
+
+    it "changes the request parameters for one-line resource creation" do
+      @user = Foo::User.create(:fullname => "Tobias Fünke")
+      @user.fullname.should == "Lindsay Fünke"
+    end
+
+    it "changes the request parameters for Model.new + #save" do
+      @user = Foo::User.new(:fullname => "Tobias Fünke")
+      @user.save
+      @user.fullname.should == "Lindsay Fünke"
+    end
+  end
 end


### PR DESCRIPTION
In order to implement some custom behavior for interacting with my API, I needed a hook to modify the request parameters sent when creating / updating my model.

In my case, I wanted to convert instances of a 'sub-model' to Rails' nested attribute parameter convention by changing `params[:child_models]` into `params[:child_models_attributes]`
