### PR TITLE
Use writer methods for data, metadata, and errors to allow customization

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -2,7 +2,7 @@ module Her
   module Model
     # This module adds ORM-like capabilities to the model
     module ORM
-      attr_reader :metadata, :errors
+      attr_accessor :data, :metadata, :errors
 
       # Initialize a new object with data received from an HTTP request
       # @private
@@ -118,11 +118,9 @@ module Her
         wrap_in_hooks(resource, :create, :save) do |resource, klass|
           params = resource.to_params
           request(params.merge(:_method => :post, :_path => "#{build_request_path(params)}")) do |parsed_data|
-            resource.instance_eval do
-              @data = parsed_data[:data]
-              @metadata = parsed_data[:metadata]
-              @errors = parsed_data[:errors]
-            end
+            resource.data = parsed_data[:data]
+            resource.metadata = parsed_data[:metadata]
+            resource.errors = parsed_data[:errors]
           end
         end
         resource
@@ -165,9 +163,9 @@ module Her
 
         self.class.wrap_in_hooks(resource, *hooks) do |resource, klass|
           klass.request(params.merge(:_method => method, :_path => "#{request_path}")) do |parsed_data|
-            @data = parsed_data[:data]
-            @metadata = parsed_data[:metadata]
-            @errors = parsed_data[:errors]
+            self.data = parsed_data[:data]
+            self.metadata = parsed_data[:metadata]
+            self.errors = parsed_data[:errors]
           end
         end
         self
@@ -183,9 +181,9 @@ module Her
         resource = self
         self.class.wrap_in_hooks(resource, :destroy) do |resource, klass|
           klass.request(:_method => :delete, :_path => "#{request_path}") do |parsed_data|
-            @data = parsed_data[:data]
-            @metadata = parsed_data[:metadata]
-            @errors = parsed_data[:errors]
+            self.data = parsed_data[:data]
+            self.metadata = parsed_data[:metadata]
+            self.errors = parsed_data[:errors]
           end
         end
         self


### PR DESCRIPTION
Add accessors for :data, :metadata, and :errors to Her::Model to allow client code to override these getter / setter methods to get custom behavior.

In my case, I needed to override the `data=` method because my API sends back an empty response (204) upon a successful POST or PUT, so I ended up doing something like the following in my own class:

``` ruby
def data=(params)
  @data = params.merge(@data)
end
```
