### PR TITLE
Automatically inherit her_api from a superclass

### DIFF
--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -2,6 +2,13 @@ module Her
   module Model
     # This module interacts with Her::API to fetch HTTP data
     module HTTP
+      # Automatically inherit a superclass' api
+      def her_api # {{{
+        @her_api ||= begin
+          superclass.her_api if superclass.respond_to?(:her_api)
+        end
+      end # }}}
+
       # Link a model with a Her::API object
       def uses_api(api) # {{{
         @her_api = api
@@ -10,7 +17,7 @@ module Her
       # Main request wrapper around Her::API. Used to make custom request to the API.
       # @private
       def request(attrs={}, &block) # {{{
-        yield @her_api.request(attrs)
+        yield her_api.request(attrs)
       end # }}}
 
       # Make a GET request and return either a collection or a resource


### PR DESCRIPTION
Without this, subclasses of a class mixing-in `Her::Model` will not have a `@her_api`, and won't be able to make requests.

Before:

``` ruby
$foo_api = Her::API.new

class Foo
  include Her::Model
  uses_api $foo_api
end

Foo.instance_eval { @her_api } # => $foo_api

class Bar < Foo
end

Bar.instance_eval { @her_api } # => nil
```

After:

``` ruby
$foo_api = Her::API.new

class Foo
  include Her::Model
  uses_api $foo_api
end

Foo.her_api # => $foo_api

class Bar < Foo
end

Bar.her_api # => $foo_api

$bar_api = Her::API.new
Bar.uses_api $bar_api
Bar.her_api # => $bar_api
Foo.her_api # => $foo_api
```
