### PR TITLE
Fix ActiveSupport version requirements

### DIFF
--- a/her.gemspec
+++ b/her.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rb-fsevent", "~> 0.9"
   s.add_development_dependency "growl", "~> 1.0"
 
-  s.add_runtime_dependency "activesupport"
+  s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "faraday", "~> 0.8"
   s.add_runtime_dependency "multi_json", "~> 1.3"
 end


### PR DESCRIPTION
ActiveSupport::Concern was introduced in Rails 3
