### PR TITLE
Model.save_existing should return resource

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -242,6 +242,7 @@ module Her
         def save_existing(id, params)
           resource = new(params.merge(:id => id))
           resource.save
+          resource
         end
 
         # Destroy an existing resource


### PR DESCRIPTION
`Model.save_existing` used to return the resource, but this was changed when fixing issue #36.

This pull request force the resource to be returned by `Model.save_existing`.
