### PR TITLE
convert string keys to symbols before storing in data Hash

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -35,6 +35,9 @@ module Her
           if setter_method_names.include?(setter_method)
             model.send(setter_method, value)
           else
+            if key.is_a?(String)
+              key = key.to_sym
+            end
             memo[key] = value
           end
           memo

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -49,6 +49,11 @@ describe Her::Model::ORM do
       @existing_user.new?.should be_false
     end
 
+    it "accepts new resource with strings as hash keys" do
+      @new_user = Foo::User.new('fullname' => "Tobias Fünke")
+      @new_user.fullname.should == "Tobias Fünke"
+    end
+
     it "handles method missing for getter" do
       @new_user = Foo::User.new(:fullname => 'Mayonegg')
       lambda { @new_user.unknown_method_for_a_user }.should raise_error(NoMethodError)


### PR DESCRIPTION
Before commit f1f8e468f4b7edab980c9adbcdc8b83848a1a348 the following code worked:

``` ruby
@new_user = Foo::User.new('fullname' => "Tobias Fünke")
puts @new_user.fullname
```

This is very neat. Given a web application, you often pass POST- or GET-params to her. The keys are often Strings in this case.

Said commit broke this. Her is looking for :fullname (Symbol) in the data Hash but only 'fullname' (String) exists. This pull requests automagically converts Strings to Symbols.
