### PR TITLE
Adds option for primary_key on models

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -32,6 +32,16 @@ module Her
       extend Her::Model::HTTP
       extend Her::Model::Hooks
 
+      # Creates an id and to_param method proxying to  primary key
+      def self.primary_key(key)
+        define_method(:id) do
+          send(key.to_sym)
+        end
+        define_method(:to_param) do
+          send(key.to_sym)
+        end
+      end
+
       # Define default settings
       root_element self.name.split("::").last.underscore
       base_path = root_element.pluralize

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -8,11 +8,14 @@ describe Her::Model do
       connection.adapter :test do |stub|
         stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json] }
         stub.get("/users/1/comments") { |env| [200, {}, [{ :id => 4, :body => "They're having a FIRESALE?" }].to_json] }
+      
+        stub.get("/messages/1") { |env| [200, {}, { :message_id => 1, :body => "Message Body" }.to_json] }
       end
     end
 
     spawn_model("Foo::User") { has_many :comments }
     spawn_model("Foo::Comment")
+    spawn_model("Foo::Message") { primary_key :message_id }
   end
   subject { Foo::User.find(1) }
 
@@ -21,6 +24,16 @@ describe Her::Model do
     it { should_not have_key(:unknown_method_for_a_user) }
     it { should have_key(:name) }
     it { should have_key(:comments) }
+  end
+
+  describe :primary_key do
+    subject { Foo::Message.find(1) } # Load the model with primary_key :message_id
+    it "proxies id to the primary key column" do
+      subject.id.should == 1
+    end
+    it "returns the primary_key value from to_param" do
+      subject.to_param.should == 1
+    end
   end
 
   describe :[] do


### PR DESCRIPTION
Adds functionality discussed in Issue #39.

Setting primary_key for a model creates methods which proxy id and to_param to the correct key.

Example usage:

```
class Person
  include Her::Model

  primary_key :person_id

end
```
