### PR TITLE
Support for custom class mapping

### DIFF
--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -49,7 +49,7 @@ module Her
                 when :has_many
                   Her::Model::Attributes.initialize_collection(klass, :data => data[data_key])
                 when :has_one, :belongs_to
-                  klass.new(data[data_key])
+                  klass.class_for_data(klass.parse(data[data_key])).new(data[data_key])
                 else
                   nil
               end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -22,6 +22,7 @@ module Her
       # @private
       def self.initialize_collection(klass, parsed_data={})
         collection_data = parsed_data[:data].map do |item_data|
+          klass = klass.class_for_data(klass.parse(item_data))
           resource = klass.new(klass.parse(item_data))
           resource.run_callbacks :find
           resource
@@ -158,6 +159,13 @@ module Her
               @attributes.include?(attribute) && @attributes[attribute].present?
             end
           end
+        end
+        
+        # Returns the class that should be instantiated to represent the given data
+        #
+        # @param [Array] parsed_data
+        def class_for_data(parsed_data)
+          self
         end
 
         # @private

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -22,8 +22,9 @@ module Her
       # @private
       def self.initialize_collection(klass, parsed_data={})
         collection_data = parsed_data[:data].map do |item_data|
-          klass = klass.class_for_data(klass.parse(item_data))
-          resource = klass.new(klass.parse(item_data))
+          parsed = klass.parse(item_data)
+          subclass = klass.class_for_data(parsed)
+          resource = subclass.new(parsed)
           resource.run_callbacks :find
           resource
         end

--- a/lib/her/model/nested_attributes.rb
+++ b/lib/her/model/nested_attributes.rb
@@ -48,6 +48,7 @@ module Her
           self.send("#{association[:name]}").assign_data(attributes)
         else
           klass = self.class.her_nearby_class(association[:class_name])
+          klass = klass.class_for_data(klass.parse(attributes))
           instance = klass.new(klass.parse(attributes))
           self.send("#{association[:name]}=", instance)
         end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -81,7 +81,7 @@ describe Her::Model::Associations do
           stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :comments => [{ :comment => { :id => 2, :body => "Tobias, you blow hard!", :user_id => 1 } }, { :comment => { :id => 3, :body => "I wouldn't mind kissing that man between the cheeks, so to speak", :user_id => 1 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 1, :name => "Bluth Company" }, :organization_id => 1 }.to_json] }
           stub.get("/users/2") { |env| [200, {}, { :id => 2, :name => "Lindsay Fünke", :organization_id => 2 }.to_json] }
           stub.get("/users/1/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }].to_json] }
-          stub.get("/users/2/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?" } }].to_json] }
+          stub.get("/users/2/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?", type: 'spam' } }].to_json] }
           stub.get("/users/2/role") { |env| [200, {}, { :id => 2, :body => "User" }.to_json] }
           stub.get("/users/1/role") { |env| [200, {}, { :id => 3, :body => "User" }.to_json] }
           stub.get("/users/1/posts") { |env| [200, {}, {:id => 1, :body => 'blogging stuff', :admin_id => 1 }.to_json] }
@@ -109,6 +109,9 @@ describe Her::Model::Associations do
       spawn_model "Foo::Comment" do
         belongs_to :user
         parse_root_in_json true
+        def self.class_for_data(data)
+          data[:type] == 'spam' ? Foo::SpamComment : self
+        end
       end
       spawn_model "Foo::Post" do
         belongs_to :admin, :class_name => 'Foo::User'
@@ -119,6 +122,9 @@ describe Her::Model::Associations do
       end
 
       spawn_model "Foo::Role"
+      
+      class Foo::SpamComment < Foo::Comment
+      end
 
       @user_with_included_data = Foo::User.find(1)
       @user_without_included_data = Foo::User.find(2)
@@ -134,6 +140,12 @@ describe Her::Model::Associations do
       @user_with_included_data.comments.first.id.should == 2
       @user_with_included_data.comments.first.body.should == "Tobias, you blow hard!"
     end
+    
+    it "maps association data to objects of a subclass if specified" do
+      @user_without_included_data.comments[0].should be_a(Foo::Comment)
+      @user_without_included_data.comments[1].should be_a(Foo::SpamComment)
+    end
+      
 
     it "does not refetch the parents models data if they have been fetched before" do
       @user_with_included_data.comments.first.user.object_id.should == @user_with_included_data.object_id


### PR DESCRIPTION
You can specify a custom subclass that should be used to map the parsed data to a Ruby object, e.g. instantiate a SpecialPerson instead of Person based on the data hash `type` attribute:

```ruby
class Person
  include Her
  def self.class_for_data(data)
    data[:type] == "special" ? SpecialPerson : self
  end
end

class SpecialPerson
end
```

This is useful when mapping associations where the destination object(s) is based on a class hierarchy (e.g. STI)

Let me know if the style and spec coverage are sufficient.