### PR TITLE
Change errors and metadata accessor methods

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -49,6 +49,10 @@ module Her
       # Define the default primary key
       primary_key :id
 
+      # Define default storage variables for errors and metadata
+      store_errors :response_errors
+      store_metadata :metadata
+
       # Configure ActiveModel callbacks
       extend ActiveModel::Callbacks
       define_model_callbacks :create, :update, :save, :find, :destroy

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -4,7 +4,7 @@ module Her
     module Attributes
       extend ActiveSupport::Concern
 
-      attr_accessor :attributes, :metadata, :response_errors
+      attr_accessor :attributes
       alias :data :attributes
       alias :data= :attributes=
 
@@ -166,6 +166,40 @@ module Her
             memo << method_name.to_s if method_name.to_s.end_with?('=')
             memo
           end
+        end
+
+        def store_errors(value = nil)
+          if @_her_store_errors
+            remove_method @_her_store_errors
+            remove_method "#{@_her_store_errors}="
+          end
+
+          @_her_store_errors ||= begin
+            superclass.store_errors if superclass.respond_to?(:store_errors)
+          end
+
+          return @_her_store_errors unless value
+          @_her_store_errors = value
+
+          define_method(@_her_store_errors) { @response_errors }
+          define_method("#{@_her_store_errors}=") { |value| @response_errors = value }
+        end
+
+        def store_metadata(value = nil)
+          if @_her_store_metadata
+            remove_method @_her_store_metadata
+            remove_method "#{@_her_store_metadata}="
+          end
+
+          @_her_store_metadata ||= begin
+            superclass.store_metadata if superclass.respond_to?(:store_metadata)
+          end
+
+          return @_her_store_metadata unless value
+          @_her_store_metadata = value
+
+          define_method(@_her_store_metadata) { @metadata }
+          define_method("#{@_her_store_metadata}=") { |value| @metadata = value }
         end
       end
     end

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -136,4 +136,31 @@ describe Her::Model::Attributes do
       hash.should == { user => false }
     end
   end
+
+  context "handling metadata and errors" do
+    before do
+      spawn_model 'Foo::User' do
+        store_errors :errors
+        store_metadata :my_data
+      end
+
+      @user = Foo::User.new(:_errors => ["Foo", "Bar"], :_metadata => { :secret => true })
+    end
+
+    it "should return errors stored in the method provided by `store_errors`" do
+      @user.errors.should == ["Foo", "Bar"]
+    end
+
+    it "should remove the default method for errors" do
+      expect { @user.response_errors }.to raise_error(NoMethodError)
+    end
+
+    it "should return metadata stored in the method provided by `store_metadata`" do
+      @user.my_data.should == { :secret => true }
+    end
+
+    it "should remove the default method for metadata" do
+      expect { @user.metadata }.to raise_error(NoMethodError)
+    end
+  end
 end

--- a/spec/model/validations_spec.rb
+++ b/spec/model/validations_spec.rb
@@ -14,9 +14,29 @@ describe "Her::Model and ActiveModel::Validations" do
     it "validates attributes when calling #valid?" do
       user = Foo::User.new
       user.should_not be_valid
+      user.errors.full_messages.should include("Fullname can't be blank")
+      user.errors.full_messages.should include("Email can't be blank")
       user.fullname = "Tobias Fünke"
       user.email = "tobias@bluthcompany.com"
       user.should be_valid
+    end
+  end
+
+  context "handling server errors" do
+    before do
+      spawn_model("Foo::Model") do
+        def errors
+          @response_errors
+        end
+      end
+
+      class User < Foo::Model; end
+      @spawned_models << :User
+    end
+
+    it "validates attributes when calling #valid?" do
+      user = User.new(:_errors => ["Email cannot be blank"])
+      user.errors.should include("Email cannot be blank")
     end
   end
 end


### PR DESCRIPTION
This adds support for `store_errors` and `store_metadata`, based on [this comment thread](https://github.com/remiprev/her/commit/3c1391c3e4dacba4b24a121ed16767077fbef279#commitcomment-3038365) started by @pencil.

Basically, it allows us to do this:

``` ruby
class User
  include Her::Model

  store_errors :errors # default is :response_errors
  store_metadata :my_data # default is :metadata
end
```

and override the `errors` method provided by `ActiveModel::Validations` and make it returns the value of `@response_errors`, which is the errors returned by the API.
