### PR TITLE
Code clean-up: Remove unnecessary interpolation

### DIFF
--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -45,7 +45,7 @@ module Her
               return nil
             end
 
-            @klass.get_resource("#{path}", @query_attrs)
+            @klass.get_resource(path, @query_attrs)
           else
             @parent.attributes[@name]
           end

--- a/lib/her/model/nested_attributes.rb
+++ b/lib/her/model/nested_attributes.rb
@@ -45,7 +45,7 @@ module Her
       def assign_nested_attributes_for_simple_association(association_type, association_name, attributes)
         association = self.class.associations[association_type].find { |association| association[:name] == association_name }
         if has_data?(association[:name])
-          self.send("#{association[:name]}").assign_data(attributes)
+          self.send(association[:name]).assign_data(attributes)
         else
           klass = self.class.her_nearby_class(association[:class_name])
           instance = klass.new(klass.parse(attributes))

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -44,7 +44,7 @@ module Her
 
         run_callbacks callback do
           run_callbacks :save do
-            self.class.request(to_params.merge(:_method => method, :_path => "#{request_path}")) do |parsed_data, response|
+            self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
               self.metadata = parsed_data[:metadata]
               self.response_errors = parsed_data[:errors]
@@ -67,7 +67,7 @@ module Her
       def destroy
         resource = self
         run_callbacks :destroy do
-          self.class.request(:_method => :delete, :_path => "#{request_path}") do |parsed_data, response|
+          self.class.request(:_method => :delete, :_path => request_path) do |parsed_data, response|
             assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
             self.metadata = parsed_data[:metadata]
             self.response_errors = parsed_data[:errors]
@@ -91,7 +91,7 @@ module Her
           params = ids.last.is_a?(Hash) ? ids.pop : {}
           results = ids.flatten.compact.uniq.map do |id|
             resource = nil
-            request(params.merge(:_method => :get, :_path => "#{build_request_path(params.merge(primary_key => id))}")) do |parsed_data, response|
+            request(params.merge(:_method => :get, :_path => build_request_path(params.merge(primary_key => id)))) do |parsed_data, response|
               if response.success?
                 resource = new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
                 resource.run_callbacks :find
@@ -156,7 +156,7 @@ module Her
         #   User.destroy_existing(1)
         #   # Called via DELETE "/users/1"
         def destroy_existing(id, params={})
-          request(params.merge(:_method => :delete, :_path => "#{build_request_path(params.merge(primary_key => id))}")) do |parsed_data, response|
+          request(params.merge(:_method => :delete, :_path => build_request_path(params.merge(primary_key => id)))) do |parsed_data, response|
             new(parse(parsed_data[:data]).merge(:_destroyed => true))
           end
         end

--- a/lib/her/model/paths.rb
+++ b/lib/her/model/paths.rb
@@ -47,7 +47,7 @@ module Her
         #  end
         def collection_path(path = nil)
           if path.nil?
-            @_her_collection_path ||= "#{root_element.to_s.pluralize}"
+            @_her_collection_path ||= root_element.to_s.pluralize
           else
             @_her_collection_path = path
             @_her_resource_path = "#{path}/:id"


### PR DESCRIPTION
There are a few places where `"#{expression}"` could be simplified to just `expression`.
