### PR TITLE
Relation#respond_to? should bubble to parent

### DIFF
--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -29,6 +29,10 @@ module Her
         fetch.send(method, *args, &blk)
       end
 
+      def respond_to?(method, *args)
+        super || fetch.respond_to?(method, *args)
+      end
+
       # @private
       def nil?
         fetch.nil?

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -23,8 +23,9 @@ describe Her::Model::Relation do
       end
 
       it "fetches the data and passes query parameters" do
-        Her::Model::Relation.any_instance.should_receive(:fetch).once.and_call_original
+        Her::Model::Relation.any_instance.should_receive(:fetch).twice.and_call_original
         @users = Foo::User.where(:admin => 1)
+        @users.should respond_to :length
         @users.length.should == 1
       end
 


### PR DESCRIPTION
When using a Her::Model::Relation instance with RSpec expectations, this sort of test will fail:

``` ruby
describe MyObject do
  describe '.all' do
    it 'should return all my fixtures' do
      expect(described_class.all).to have(5).items
    end
  end
end
```

It'll fail because the Her::Model::Relation instance looks like it doesn't implement `#size` or `#length`, so RSpec will try to call the `items` method on it. In turn, Her::Model::Relation will send the `items` method on to the Her::Collection. You'll get this (fairly opaque) error back:

```
Failure/Error: expect(described_class.all).to have(5).items
NoMethodError:
  undefined method `items' for #<Her::Collection:0x007fd5e22a5e80>
```

This patch adds a regression test and fixes it.
