### PR TITLE
Refactor Nested Attributes

### DIFF
--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -75,7 +75,7 @@ module Her
         # @private
         def fetch
           foreign_key_value = @parent.attributes[@opts[:foreign_key].to_sym]
-          return nil if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @query_attrs.empty?) || foreign_key_value.blank?
+          return nil if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @query_attrs.empty?) || (@parent.persisted? && foreign_key_value.blank?)
 
           if @parent.attributes[@name].blank? || @query_attrs.any?
             path = begin
@@ -87,6 +87,15 @@ module Her
             @klass.get_resource(path, @query_attrs)
           else
             @parent.attributes[@name]
+          end
+        end
+
+        # @private
+        def assign_nested_attributes(attributes)
+          if @parent.attributes[@name].blank?
+            @parent.attributes[@name] = @klass.new(@klass.parse(attributes))
+          else
+            @parent.attributes[@name].assign_attributes(attributes)
           end
         end
       end

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -98,6 +98,11 @@ module Her
 
           output
         end
+
+        # @private
+        def assign_nested_attributes(attributes)
+          @parent.attributes[@name] = Her::Model::Attributes.initialize_collection(@klass, :data => attributes)
+        end
       end
     end
   end

--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -87,6 +87,15 @@ module Her
             @parent.attributes[@name]
           end
         end
+
+        # @private
+        def assign_nested_attributes(attributes)
+          if @parent.attributes[@name].blank?
+            @parent.attributes[@name] = @klass.new(@klass.parse(attributes))
+          else
+            @parent.attributes[@name].assign_attributes(attributes)
+          end
+        end
       end
     end
   end

--- a/lib/her/model/nested_attributes.rb
+++ b/lib/her/model/nested_attributes.rb
@@ -5,55 +5,39 @@ module Her
 
       module ClassMethods
         # Allow nested attributes for an association
+        #
+        # @example
+        #   class User
+        #     include Her::Model
+        #
+        #     has_one :role
+        #     accepts_nested_attributes_for :role
+        #   end
+        #
+        #   class Role
+        #     include Her::Model
+        #   end
+        #
+        #   user = User.new(name: "Tobias", role_attributes: { title: "moderator" })
+        #   user.role # => #<Role title="moderator">
         def accepts_nested_attributes_for(*association_names)
-          association_names.each do |association_name|
-            type = nil
-            [:belongs_to, :has_one, :has_many].each do |association_type|
-              if !associations[association_type].nil? && associations[association_type].any? { |association| association[:name] == association_name }
-                type = association_type
-              end
-            end
+          allowed_association_names = associations.inject([]) { |memo, (name, details)| memo << details }.flatten.map { |a| a[:name] }
 
-            raise(AssociationUnknownError.new("Unknown association name :#{association_name}")) if type.nil?
+          association_names.each do |association_name|
+            unless allowed_association_names.include?(association_name)
+              raise Her::Errors::AssociationUnknownError.new("Unknown association name :#{association_name}")
+            end
 
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
               if method_defined?(:#{association_name}_attributes=)
                 remove_method(:#{association_name}_attributes=)
               end
+
               def #{association_name}_attributes=(attributes)
-                assign_nested_attributes_for_#{type}_association(:#{association_name}, attributes)
+                self.#{association_name}.assign_nested_attributes(attributes)
               end
             RUBY
           end
-        end
-      end
-
-      # @private
-      def assign_nested_attributes_for_belongs_to_association(association_name, attributes)
-        assign_nested_attributes_for_simple_association(:belongs_to, association_name, attributes)
-      end
-
-      # @private
-      def assign_nested_attributes_for_has_one_association(association_name, attributes)
-        assign_nested_attributes_for_simple_association(:has_one, association_name, attributes)
-      end
-
-      # @private
-      def assign_nested_attributes_for_has_many_association(association_name, attributes)
-        association = self.class.associations[:has_many].find { |association| association[:name] == association_name }
-        klass = self.class.her_nearby_class(association[:class_name])
-        self.send("#{association[:name]}=", Her::Model::Attributes.initialize_collection(klass, :data => attributes))
-      end
-
-      private
-      def assign_nested_attributes_for_simple_association(association_type, association_name, attributes)
-        association = self.class.associations[association_type].find { |association| association[:name] == association_name }
-        if has_attribute?(association[:name])
-          self.send(association[:name]).assign_attributes(attributes)
-        else
-          klass = self.class.her_nearby_class(association[:class_name])
-          instance = klass.new(klass.parse(attributes))
-          self.send("#{association[:name]}=", instance)
         end
       end
     end

--- a/spec/model/nested_attributes_spec.rb
+++ b/spec/model/nested_attributes_spec.rb
@@ -95,4 +95,12 @@ describe Her::Model::NestedAttributes do
       end
     end
   end
+
+  context "with an unknown association" do
+    it "raises an error" do
+      expect {
+        spawn_model("Foo::User") { accepts_nested_attributes_for :company }
+      }.to raise_error(Her::Errors::AssociationUnknownError, 'Unknown association name :company')
+    end
+  end
 end


### PR DESCRIPTION
I refactored the `Her::Model::NestedAttributes` module to move the logic away from it and into the individual association classes.

@pencil Since you’re the original author of the module, I’d like to get your feedback on this :smile: Thanks!

Feedback from everyone is also welcomed!
