### PR TITLE
Don't reuse Relation objects between calls of Model.all

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -35,7 +35,6 @@ module Her
         #   user = User.find(1)
         #   user.comments.where(:approved => 1) # Fetched via GET "/users/1/comments?approved=1
         def where(params = {})
-          return self if params.blank?
           self.clone.tap { |a| a.params = a.params.merge(params) }
         end
         alias all where

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -30,7 +30,6 @@ module Her
       #   @users = User.where(:approved => 1).all
       #   # Fetched via GET "/users?approved=1"
       def where(params = {})
-        return self if params.blank?
         self.clone.tap do |r|
           r.params = r.params.merge(params)
           r.clear_fetch_cache!


### PR DESCRIPTION
Right now, calling Model.all twice will return the same instance of Her::Model::Relation, which means any newly-created objects won't be included.

I don't think there is any elegant way to actually cache the `.all` relation through memoization and not introduce challenging inconsistencies. This patch adds a test and ensures that we _always_ clone the existing relation.

Here are a couple other places I looked to check how other libraries implement `.all`. No other libraries attempt to reuse the same object in memory between calls.
- [ActiveRecord::Scoping::Named.all](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb#L24)
- [ActiveResource::Base.all](https://github.com/rails/activeresource/blob/master/lib/active_resource/base.rb#L898)
