### PR TITLE
Add ability to request the new object via API when calling build

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,20 @@ You can use the association methods to build new objects and save them.
 # => [#<Comment id=3 body="Hello world." user_id=1>]
 ```
 
+You can also explicitly request a new object via the API when using ``build``. This is useful if you're dealing with default attributes.
+
+```ruby
+class Comment
+  include Her::Model
+  request_new_object_on_build true
+end
+
+@user = User.find(1)
+@user.comments.build(body: "Just a draft")
+# GET "/users/1/comments/new" with `body=Just+a+draft.`
+# => [#<Comment id=nil body="Just a draft" archived=false user_id=1>]
+```
+
 #### Notes about paths
 
 Resources must always have all the required attributes to build their complete path. For example, if you have these models:

--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -53,6 +53,7 @@ module Her
       method_for :update, :put
       method_for :find, :get
       method_for :destroy, :delete
+      method_for :new, :get
 
       # Define the default primary key
       primary_key :id

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -45,7 +45,7 @@ module Her
         #   new_organization = user.organization.build(:name => "Foo Inc.")
         #   new_organization # => #<Organization name="Foo Inc.">
         def build(attributes = {})
-          @klass.new(attributes)
+          @klass.build(attributes)
         end
 
         # Create a new object, save it and associate it to the parent

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -49,7 +49,7 @@ module Her
         #   new_comment = user.comments.build(:body => "Hello!")
         #   new_comment # => #<Comment user_id=1 body="Hello!">
         def build(attributes = {})
-          @klass.new(attributes.merge(:"#{@parent.singularized_resource_name}_id" => @parent.id))
+          @klass.build(attributes.merge(:"#{@parent.singularized_resource_name}_id" => @parent.id))
         end
 
         # Create a new object, save it and add it to the associated collection

--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -44,7 +44,7 @@ module Her
         #   new_role = user.role.build(:title => "moderator")
         #   new_role # => #<Role user_id=1 title="moderator">
         def build(attributes = {})
-          @klass.new(attributes.merge(:"#{@parent.singularized_resource_name}_id" => @parent.id))
+          @klass.build(attributes.merge(:"#{@parent.singularized_resource_name}_id" => @parent.id))
         end
 
         # Create a new object, save it and associate it to the parent

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -165,6 +165,24 @@ module Her
           @method_for[action] = method.to_s.downcase.to_sym
         end
 
+        # Build a new resource with the given attributes.
+        # If the request_new_object_on_build flag is set, the new object is requested via API.
+        def build(attributes = {})
+          params = attributes
+          return self.new(params) unless self.request_new_object_on_build?
+
+          path = self.build_request_path(params.merge(self.primary_key => 'new'))
+          method = self.method_for(:new)
+
+          resource = nil
+          self.request(params.merge(:_method => method, :_path => path)) do |parsed_data, response|
+            if response.success?
+              resource = self.new_from_parsed_data(parsed_data)
+            end
+          end
+          resource
+        end
+
         private
         # @private
         def blank_relation

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -61,6 +61,23 @@ module Her
         end
         alias parse_root_in_json? parse_root_in_json
 
+        # Return or change the value of `request_new_object_on_build`
+        #
+        # @example
+        #   class User
+        #     include Her::Model
+        #     request_new_object_on_build true
+        #   end
+        def request_new_object_on_build(value = nil)
+          @_her_request_new_object_on_build ||= begin
+            superclass.request_new_object_on_build if superclass.respond_to?(:request_new_object_on_build)
+          end
+
+          return @_her_request_new_object_on_build unless value
+          @_her_request_new_object_on_build = value
+        end
+        alias request_new_object_on_build? request_new_object_on_build
+
         # Return or change the value of `root_element`. Always defaults to the base name of the class.
         #
         # @example

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -17,7 +17,7 @@ module Her
 
       # Build a new resource
       def build(attributes = {})
-        @parent.new(@params.merge(attributes))
+        @parent.build(@params.merge(attributes))
       end
 
       # Add a query string parameter


### PR DESCRIPTION
This PR adds the ability to request the new object via the API when calling build. Just set the `request_new_object_on_build` flag and voilà, there you go!
#### Example:

``` ruby
class Comment
  include Her::Model
  request_new_object_on_build true
end

@user = User.find(1)
@user.comments.build(body: "Just a draft")
# GET "/users/1/comments/new" with `body=Just+a+draft.`
# => [#<Comment id=nil body="Just a draft" archived=false user_id=1>]
```
