### PR TITLE
JRuby fix for associations

### DIFF
--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -31,7 +31,7 @@ module Her
         # @private
         def associations
           @_her_associations ||= begin
-            superclass.respond_to?(:associations) ? superclass.associations.dup : Hash.new { |h,k| h[k] = [] }
+            superclass.respond_to?(:associations) ? superclass.associations.dup : Hash.new { |h,k| h[k] = [].to_set }
           end
         end
 

--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -31,7 +31,7 @@ module Her
         # @private
         def associations
           @_her_associations ||= begin
-            superclass.respond_to?(:associations) ? superclass.associations.dup : Hash.new { |h,k| h[k] = [].to_set }
+            superclass.respond_to?(:associations) ? superclass.associations.dup : Hash.new { |h,k| h[k] = [] }
           end
         end
 

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -22,7 +22,7 @@ module Her
 
           klass = klass.her_nearby_class(association[:class_name])
           if klass.parse_root_in_json
-            attributes = data[data_key][data_key]
+            attributes = data[data_key][data[data_key].keys.first]
           else
             attributes = data[data_key]
           end

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -21,7 +21,12 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          { association[:name] => klass.new(data[data_key]) }
+          if klass.parse_root_in_json
+            attributes = data[data_key][data_key]
+          else
+            attributes = data[data_key]
+          end
+          { association[:name] => klass.new(attributes) }
         end
 
         # @private

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -21,7 +21,7 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          if klass.parse_root_in_json
+          if klass.parse_root_in_json && data[data_key].keys.size <= 1
             attributes = data[data_key][data[data_key].keys.first]
           else
             attributes = data[data_key]

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -12,7 +12,7 @@ module Her
             :foreign_key => "#{name}_id",
             :path => "/#{name.to_s.pluralize}/:id"
           }.merge(opts)
-          klass.associations[:belongs_to] << opts
+          klass.associations[:belongs_to] << opts unless klass.associations[:belongs_to].include? opts
 
           klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -12,7 +12,7 @@ module Her
             :path           => "/#{name}",
             :inverse_of => nil
           }.merge(opts)
-          klass.associations[:has_many] << opts
+          klass.associations[:has_many] << opts unless klass.associations[:has_many].include? opts
 
           klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}

--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -11,7 +11,7 @@ module Her
             :default => nil,
             :path => "/#{name}"
           }.merge(opts)
-          klass.associations[:has_one] << opts
+          klass.associations[:has_one] << opts unless klass.associations[:has_one].include? opts
 
           klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}


### PR DESCRIPTION
In JRuby on Rails with Puma in production mode with config.threadsafe!, a Her::Model was getting loaded twice, so the associations in that model were added twice and there is no check for duplicate associations in Her::Model::Associations. This resulted in unexpected behavior when parsing has_many associations. association_class.parse gets invoked twice for the same association and second time the data argument passed contains Her::Association object instead of Hash. Hence it sets the attributes of association class instance as nil.
