### PR TITLE
Allow specifying a field to identify new records.

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,31 @@ user.destroy
 # DELETE "/users/4fd89a42ff204b03a905c535"
 ```
 
+### Custom new record identifier
+
+By default, the presence or absence of the `primary_key` field will be used to
+determine if a record is new or not.  In some cases, for example if you are
+using 'slugs' in your URLs, this is not desirable.  In this case you can
+specify a different field to use than `primary_key`.
+
+```ruby
+class User
+  include Her::Model
+  primary_key :slug
+  new_record_key :id
+end
+
+user = User.find("tobias")
+# GET "/users/1", response is { "id": 1, "name": "Tobias", "slug": "tobias" }
+
+user.new?
+# => false
+
+user = User.new(:slug => 'maeby')
+user.new?
+# => true
+```
+
 ### Inheritance
 
 If all your models share the same settings, you might want to make them children of a class and only include `Her::Model` in that class. However, there are a few settings that don’t get passed to the children classes:

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -134,6 +134,11 @@ module Her
         @attributes[self.class.primary_key]
       end
 
+      # Return the value of the model `new_record_key` attribute
+      def new_record_key
+        @attributes[self.class.new_record_key || self.class.primary_key]
+      end
+
       # Return `true` if the other object is also a Her::Model and has matching data
       #
       # @private

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -6,7 +6,7 @@ module Her
 
       # Return `true` if a resource was not saved yet
       def new?
-        id.nil?
+        new_record_key.nil?
       end
 
       # Return `true` if a resource is not `#new?`

--- a/lib/her/model/paths.rb
+++ b/lib/her/model/paths.rb
@@ -38,6 +38,25 @@ module Her
           @_her_primary_key = value.to_sym
         end
 
+        # Define the new record key field that will be used to identify if a
+        # record should be considered new or existing.
+        #
+        # @example
+        #  class User
+        #    include Her::Model
+        #    new_record_key 'user_id'
+        #  end
+        #
+        # @param [Symbol] value
+        def new_record_key(value = nil)
+          @_her_new_record_key ||= begin
+            superclass.new_record_key if superclass.respond_to?(:new_record_key)
+          end
+
+          return @_her_new_record_key unless value
+          @_her_new_record_key = value.to_sym
+        end
+
         # Defines a custom collection path for the resource
         #
         # @example

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -13,6 +13,7 @@ describe Her::Model::ORM do
           stub.get("/users") { |env| [200, {}, [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }].to_json] }
           stub.get("/admin_users") { |env| [200, {}, [{ :admin_id => 1, :name => "Tobias Fünke" }, { :admin_id => 2, :name => "Lindsay Fünke" }].to_json] }
           stub.get("/admin_users/1") { |env| [200, {}, { :admin_id => 1, :name => "Tobias Fünke" }.to_json] }
+          stub.get("/slug_users/slug") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -23,6 +24,12 @@ describe Her::Model::ORM do
       spawn_model "Foo::AdminUser" do
         uses_api api
         primary_key :admin_id
+      end
+
+      spawn_model "Foo::SlugUser" do
+        uses_api api
+        primary_key :slug
+        new_record_key :id
       end
     end
 
@@ -60,6 +67,14 @@ describe Her::Model::ORM do
       @new_user.should be_new
 
       @existing_user = Foo::AdminUser.find(1)
+      @existing_user.should_not be_new
+    end
+
+    it 'handles new resource with custom new resource key' do
+      @new_user = Foo::SlugUser.new(:fullname => 'Lindsay Fünke')
+      @new_user.should be_new
+
+      @existing_user = Foo::SlugUser.find('slug')
       @existing_user.should_not be_new
     end
   end


### PR DESCRIPTION
It is possible to use 'slugged' resource URLs using the `primary_key` method, however doing so causes her to consider the presence or absence of the 'slug' field as an indicator of whether the record is `new?`

This PR makes it possible to specify a different field to identify whether a record is new or not, which defaults to the same field as `primary_key`

```
class MySluggedResource
  primary_key 'slug'
  new_record_key 'id'
end
```
