### PR TITLE
don't include associated models in to_params

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -24,7 +24,8 @@ module Her
 
         # @private
         def to_params(attributes)
-          include_root_in_json? ? { included_root_element => attributes.dup.symbolize_keys } : attributes.dup.symbolize_keys
+          params = attributes.except(*associations.values.flatten.collect { |a| a[:data_key] }).symbolize_keys
+          include_root_in_json? ? { included_root_element => params } : params
         end
 
         # Return or change the value of `include_root_in_json`


### PR DESCRIPTION
Let's assume the following models:

``` ruby
class User
  include Her::Model
  has_many :blog_posts
end

class BlogPost
  include Her::Model
end
```

Now when I consume an API which includes the corresponding blog posts in the user response, I get an object like this:

```
Foo::User.find(1)
> #<Foo::User(users/1) id=1 name="Tobias Fünke" blog_posts=#<Her::Model::Associations::HasManyAssociation:0x007ff6aa2e9d68 @parent=#<Foo::User(users/1) id=1 name="Tobias Fünke" blog_posts=#<Her::Model::Associations::HasManyAssociation:0x007ff6aa2e9d68 ...>>, @opts={:class_name=>"BlogPost", :name=>:blog_posts, :data_key=>:blog_posts, :default=>[], :path=>"/blog_posts", :inverse_of=>nil}, @params={}, @klass=Foo::BlogPost, @name=:blog_posts>>
```

When trying to save this model, it sends the following parameters:

```
{:id=>1, :name=>"Tobias Fünke", :blog_posts=>[#<Foo::BlogPost(blog_posts/1) id=1 title="Welcome To codinghell.ch" user_id=1>, #<Foo::BlogPost(blog_posts/2) id=2 title="How Awesome Is This" user_id=1>]}
```

This doesn't seem correct to me. This PR changes the to_params method in `/lib/her/model/parse.rb` to exclude associated models from parameters altogether.
