### PR TITLE
Fix deprecation warnings with RSpec 2.14

### DIFF
--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -19,17 +19,17 @@ describe Her::Model::Attributes do
     it "handles method missing for getter" do
       @new_user = Foo::User.new(:fullname => 'Mayonegg')
       expect { @new_user.unknown_method_for_a_user }.to raise_error(NoMethodError)
-      expect { @new_user.fullname }.to_not raise_error(NoMethodError)
+      expect { @new_user.fullname }.not_to raise_error()
     end
 
     it "handles method missing for setter" do
       @new_user = Foo::User.new
-      expect { @new_user.fullname = "Tobias Fünke" }.to_not raise_error(NoMethodError)
+      expect { @new_user.fullname = "Tobias Fünke" }.not_to raise_error()
     end
 
     it "handles method missing for query" do
       @new_user = Foo::User.new
-      expect { @new_user.fullname? }.to_not raise_error(NoMethodError)
+      expect { @new_user.fullname? }.not_to raise_error()
     end
 
     it "handles respond_to for getter" do
@@ -113,7 +113,7 @@ describe Her::Model::Attributes do
     end
 
     it "returns false for a non-resource with the same data" do
-      fake_user = stub(:data => { :id => 1, :fullname => "Lindsay Fünke" })
+      fake_user = double(:data => { :id => 1, :fullname => "Lindsay Fünke" })
       user.should_not == fake_user
     end
 


### PR DESCRIPTION
Running the test suite with RSpec 2.14 gives these warnings:

```
Her::Model::Attributes ..DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error()` instead. Called from /usr/local/opt/rbenv/versions/1.9.3-p374/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.14.0/lib/rspec/matchers/built_in/raise_error.rb:53:in `does_not_match?'.
.DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error()` instead. Called from /usr/local/opt/rbenv/versions/1.9.3-p374/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.14.0/lib/rspec/matchers/built_in/raise_error.rb:53:in `does_not_match?'.
.DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error()` instead. Called from /usr/local/opt/rbenv/versions/1.9.3-p374/lib/ruby/gems/1.9.1/gems/rspec-expectations-2.14.0/lib/rspec/matchers/built_in/raise_error.rb:53:in `does_not_match?'.
............DEPRECATION: stub is deprecated. Use double instead. Called from /Users/yozwork/Work/her/spec/model/attributes_spec.rb:116:in `block (3 levels) in <top (required)>'.
```

This patch fixes them.
