### PR TITLE
Add option to accept empty responses

### DIFF
--- a/lib/her/middleware/parse_json.rb
+++ b/lib/her/middleware/parse_json.rb
@@ -3,7 +3,7 @@ module Her
     class ParseJSON < Faraday::Response::Middleware
       # @private
       def parse_json(body = nil)
-        body ||= '{}'
+        body = '{}' if body.blank?
         message = "Response from the API must behave like a Hash or an Array (last JSON response was #{body.inspect})"
 
         json = begin

--- a/spec/middleware/first_level_parse_json_spec.rb
+++ b/spec/middleware/first_level_parse_json_spec.rb
@@ -7,6 +7,7 @@ describe Her::Middleware::FirstLevelParseJSON do
   let(:body_with_errors) { "{\"id\": 1, \"name\": \"Tobias Fünke\", \"errors\": { \"name\": [ \"not_valid\", \"should_be_present\" ] }, \"metadata\": 3}" }
   let(:body_with_malformed_json) { "wut." }
   let(:body_with_invalid_json) { "true" }
+  let(:empty_body) { '' }
   let(:nil_body) { nil }
 
   it "parses body as json" do
@@ -43,6 +44,10 @@ describe Her::Middleware::FirstLevelParseJSON do
 
   it 'ensures that a nil response returns an empty hash' do
     subject.parse(nil_body)[:data].should eq({})
+  end
+
+  it 'ensures that an empty response returns an empty hash' do
+    subject.parse(empty_body)[:data].should eq({})
   end
 
   context 'with status code 204' do


### PR DESCRIPTION
This PR adds an option to the Her setup so that empty responses are considered valid, besides hashes and arrays.
