### PR TITLE
Association should respond to #empty? for compatibility with ActiveSupport's #blank? method

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -92,6 +92,11 @@ module Her
         end
 
         # @private
+        def empty?
+          fetch.empty?
+        end
+
+        # @private
         def kind_of?(thing)
           fetch.kind_of?(thing)
         end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -217,6 +217,11 @@ describe Her::Model::Associations do
       comment.id.should eq(5)
     end
 
+    it "'s associations responds to #empty?" do
+      @user_without_included_data.organization.respond_to?(:empty?).should be_true
+      @user_without_included_data.organization.should_not be_empty
+    end
+
     [:create, :save_existing, :destroy].each do |type|
       context "after #{type}" do
         let(:subject) { self.send("user_with_included_data_after_#{type}")}


### PR DESCRIPTION
In our Rails project `user.comments.blank?` always returns `false`, because the association does not respond to `empty?`. See https://github.com/rails/rails/blob/2a371368c91789a4d689d6a84eb20b238c37678a/activesupport/lib/active_support/core_ext/object/blank.rb#L15
