### PR TITLE
Allow specifying a custom finder key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,21 @@ user.destroy
 # DELETE "/users/4fd89a42ff204b03a905c535"
 ```
 
+### Custom finder key
+
+In the case that your API does not use the resource's primary key to find
+records, you can specify a different field to use with `finder_key`.
+
+```ruby
+class User
+  include Her::Model
+  finder_key :slug
+end
+
+user = User.find("tobias")
+# GET "/users/tobias", response is { "id": 1, "name": "Tobias", "slug": "tobias" }
+```
+
 ### Inheritance
 
 If all your models share the same settings, you might want to make them children of a class and only include `Her::Model` in that class. However, there are a few settings that don’t get passed to the children classes:

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -38,7 +38,7 @@ module Her
           return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && @parent.attributes[@name].empty? && @params.empty?
 
           if @parent.attributes[@name].blank? || @params.any?
-            path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}" }
+            path = build_association_path lambda { "#{@parent.resource_request_path(@params)}#{@opts[:path]}" }
             @klass.get(path, @params)
           else
             @parent.attributes[@name]
@@ -82,7 +82,7 @@ module Her
         #   user.comments.find(3) # Fetched via GET "/users/1/comments/3
         def find(id)
           return nil if id.blank?
-          path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}/#{id}" }
+          path = build_association_path lambda { "#{@parent.resource_request_path(@params)}#{@opts[:path]}/#{id}" }
           @klass.get(path, @params)
         end
 

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -76,7 +76,7 @@ module Her
 
           if @parent.attributes[@name].blank? || @params.any?
             path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
-            path = build_association_path lambda { @klass.build_request_path(path_params) }
+            path = build_association_path lambda { @klass.build_resource_request_path(path_params) }
             @klass.get(path, @params)
           else
             @parent.attributes[@name]

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -134,6 +134,11 @@ module Her
         @attributes[self.class.primary_key]
       end
 
+      # Return the value of the model `finder_key` attribute
+      def finder_key
+        @attributes[self.class.finder_key]
+      end
+
       # Return `true` if the other object is also a Her::Model and has matching data
       #
       # @private

--- a/lib/her/model/introspection.rb
+++ b/lib/her/model/introspection.rb
@@ -13,7 +13,7 @@ module Her
       #   p @user # => #<User(/users/1) id=1 name="Tobias Fünke">
       def inspect
         resource_path = begin
-          request_path
+          new? ? collection_request_path : resource_request_path
         rescue Her::Errors::PathError => e
           "<unknown path, missing `#{e.missing_parameter}`>"
         end

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -65,7 +65,7 @@ module Her
       # @private
       def fetch
         @_fetch ||= begin
-          path = @parent.build_request_path(@params)
+          path = @parent.build_collection_request_path(@params)
           method = @parent.method_for(:find)
           @parent.request(@params.merge(:_method => method, :_path => path)) do |parsed_data, response|
             @parent.new_collection(parsed_data)
@@ -89,7 +89,7 @@ module Her
           resource = nil
           request_params = params.merge(
             :_method => @parent.method_for(:find),
-            :_path => @parent.build_request_path(params.merge(@parent.primary_key => id))
+            :_path => @parent.build_resource_request_path(params.merge(@parent.finder_key => id))
           )
 
           @parent.request(request_params) do |parsed_data, response|

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -8,60 +8,63 @@ describe Her::Model::Paths do
         spawn_model "Foo::User"
       end
 
-      describe "#build_request_path" do
+      describe "#build_*_request_path" do
         it "builds paths with defaults" do
-          Foo::User.build_request_path(:id => "foo").should == "users/foo"
-          Foo::User.build_request_path(:id => nil).should == "users"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.build_resource_request_path(:id => "foo").should == "users/foo"
+          Foo::User.build_collection_request_path.should == "users"
         end
 
         it "builds paths with custom collection path" do
           Foo::User.collection_path "/utilisateurs"
-          Foo::User.build_request_path(:id => "foo").should == "/utilisateurs/foo"
-          Foo::User.build_request_path.should == "/utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo").should == "/utilisateurs/foo"
+          Foo::User.build_collection_request_path.should == "/utilisateurs"
         end
 
         it "builds paths with custom relative collection path" do
           Foo::User.collection_path "utilisateurs"
-          Foo::User.build_request_path(:id => "foo").should == "utilisateurs/foo"
-          Foo::User.build_request_path.should == "utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo").should == "utilisateurs/foo"
+          Foo::User.build_collection_request_path.should == "utilisateurs"
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
+          Foo::User.build_collection_request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:organization_id => "acme").should == "/organizations/acme/utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo", :organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
+          Foo::User.build_collection_request_path(:organization_id => "acme").should == "/organizations/acme/utilisateurs"
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
+          Foo::User.build_collection_request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:organization_id => "acme").should == "organizations/acme/utilisateurs"
+          Foo::User.build_resource_request_path(:id => "foo", :organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
+          Foo::User.build_collection_request_path(:organization_id => "acme").should == "organizations/acme/utilisateurs"
         end
 
         it "builds paths with custom item path" do
           Foo::User.resource_path "/utilisateurs/:id"
-          Foo::User.build_request_path(:id => "foo").should == "/utilisateurs/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.build_resource_request_path(:id => "foo").should == "/utilisateurs/foo"
+          Foo::User.build_collection_request_path.should == "users"
         end
 
         it "builds paths with custom relative item path" do
           Foo::User.resource_path "utilisateurs/:id"
-          Foo::User.build_request_path(:id => "foo").should == "utilisateurs/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.build_resource_request_path(:id => "foo").should == "utilisateurs/foo"
+          Foo::User.build_collection_request_path.should == "users"
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
-          expect { Foo::User.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::User.build_resource_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
+        end
+
+        it "raises an exception when trying to build a resource path without an id" do
+          expect { Foo::User.build_resource_request_path(:id => nil) }.to raise_error(Her::Errors::PathError)
         end
       end
     end
@@ -71,56 +74,56 @@ describe Her::Model::Paths do
         spawn_model "Foo::AdminUser"
       end
 
-      describe "#build_request_path" do
+      describe "#build_*_request_path" do
         it "builds paths with defaults" do
-          Foo::AdminUser.build_request_path(:id => "foo").should == "admin_users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo").should == "admin_users/foo"
+          Foo::AdminUser.build_collection_request_path.should == "admin_users"
         end
 
         it "builds paths with custom collection path" do
           Foo::AdminUser.collection_path "/users"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "/users/foo"
-          Foo::AdminUser.build_request_path.should == "/users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo").should == "/users/foo"
+          Foo::AdminUser.build_collection_request_path.should == "/users"
         end
 
         it "builds paths with custom relative collection path" do
           Foo::AdminUser.collection_path "users"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "users/foo"
-          Foo::AdminUser.build_request_path.should == "users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo").should == "users/foo"
+          Foo::AdminUser.build_collection_request_path.should == "users"
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          Foo::AdminUser.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/users/foo"
-          Foo::AdminUser.build_request_path(:_organization_id => "acme").should == "/organizations/acme/users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/users/foo"
+          Foo::AdminUser.build_collection_request_path(:_organization_id => "acme").should == "/organizations/acme/users"
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          Foo::AdminUser.build_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/users/foo"
-          Foo::AdminUser.build_request_path(:_organization_id => "acme").should == "organizations/acme/users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/users/foo"
+          Foo::AdminUser.build_collection_request_path(:_organization_id => "acme").should == "organizations/acme/users"
         end
 
         it "builds paths with custom item path" do
           Foo::AdminUser.resource_path "/users/:id"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "/users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo").should == "/users/foo"
+          Foo::AdminUser.build_collection_request_path.should == "admin_users"
         end
 
         it "builds paths with custom relative item path" do
           Foo::AdminUser.resource_path "users/:id"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.build_resource_request_path(:id => "foo").should == "users/foo"
+          Foo::AdminUser.build_collection_request_path.should == "admin_users"
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          expect { Foo::AdminUser.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.build_resource_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
 
         it "raises exceptions when building a relative path without required custom variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          expect { Foo::AdminUser.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.build_resource_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
       end
     end
@@ -152,10 +155,10 @@ describe Her::Model::Paths do
         spawn_model "Foo::User"
       end
 
-      describe "#build_request_path" do
+      describe "#build_*_request_path" do
         it "builds paths with defaults" do
-          Foo::User.build_request_path(:id => "foo").should == "users/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.build_resource_request_path(:id => "foo").should == "users/foo"
+          Foo::User.build_collection_request_path.should == "users"
         end
       end
     end
@@ -173,15 +176,15 @@ describe Her::Model::Paths do
         end
       end
 
-      describe '#build_request_path' do
+      describe '#build_*_request_path' do
         it 'uses the correct primary key attribute' do
-          User.build_request_path(:UserId => 'foo').should == 'users/foo'
-          User.build_request_path(:id => 'foo').should == 'users'
+          User.build_resource_request_path(:UserId => 'foo').should == 'users/foo'
+          User.build_collection_request_path(:id => 'foo').should == 'users'
         end
 
         it 'replaces :id with the appropriate primary key' do
-          Customer.build_request_path(:customer_id => 'joe').should == 'customers/joe'
-          Customer.build_request_path(:id => 'joe').should == 'customers'
+          Customer.build_resource_request_path(:customer_id => 'joe').should == 'customers/joe'
+          Customer.build_collection_request_path(:id => 'joe').should == 'customers'
         end
       end
     end


### PR DESCRIPTION
This allows support for cases where the API does not use the primary
key in the URL, for example /users/username rather than /users/1.

This has required a major rework of the request_path methods as the
correct path can no longer be inferred from the parameters alone.  The
decision as to whether to request a collection_path or resource_path has
been pushed up into each occurence of the calling code.

Closes #148