### PR TITLE
added support for legacy ruby version gem requirements

### DIFF
--- a/her.gemspec
+++ b/her.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "fivemat", "~> 1.2"
   s.add_development_dependency "json", "~> 1.7.7"
 
+  s.add_runtime_dependency "activemodel", ">= 3.0.0"
+  s.add_runtime_dependency "activesupport", ">= 3.0.0"
   s.add_runtime_dependency "faraday", "~> 0.8"
   s.add_runtime_dependency "multi_json", "~> 1.7"
 end


### PR DESCRIPTION
When doing a bundle install bundler was trying to install 4.0 gem versions for activemodel and activesupport. If the ruby version was 1.9.2 or earlier this blows up as they require 1.9.3 or greater. I added a check for the ruby version in order to select the right version of activesupport and activemodel for legacy ruby versions.
