### PR TITLE
When setting primary_key belongs_to stop working 

### DIFF
--- a/spec/model/primary_key_belongs_to_fail_spec.rb
+++ b/spec/model/primary_key_belongs_to_fail_spec.rb
@@ -1,0 +1,60 @@
+# encoding: utf-8
+require File.join(File.dirname(__FILE__), "../spec_helper.rb")
+
+describe "primary_key belongs_to fail", :focus => true do
+
+  context "without primary_key set" do
+    before do
+      Her::API.setup :url => "https://api.example.com/api" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.adapter :test do |stub|
+          stub.get('/api/actors/x1') { [200, {}, MultiJson.encode({
+            "uid"           => "x1",
+            "organization"  => {"name" => "TestOrg"},
+            "user"          => {"email" => "x1@localhost"}
+          })]}
+        end
+      end
+
+      spawn_model "Foo::Actor" do
+        belongs_to :user
+      end
+
+      spawn_model "Foo::User" do
+
+      end
+    end
+
+    it "works" do
+      Foo::Actor.find("x1").user.email.should == "x1@localhost"
+    end
+  end
+
+  context "with primary_key set" do
+    before do
+      Her::API.setup :url => "https://api.example.com/api" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.adapter :test do |stub|
+          stub.get('/api/actors/x1') { [200, {}, MultiJson.encode({
+            "uid"           => "x1",
+            "organization"  => {"name" => "TestOrg"},
+            "user"          => {"email" => "x1@localhost"}
+          })]}
+        end
+      end
+
+      spawn_model "Foo::Actor" do
+        primary_key :uid
+        belongs_to :user
+      end
+
+      spawn_model "Foo::User" do
+
+      end
+    end
+
+    it "works" do
+      Foo::Actor.find("x1").user.email.should == "x1@localhost"
+    end
+  end
+end


### PR DESCRIPTION
With models like:

``` ruby
class Actor
  include Her::Model
  belongs_to :user
end

class User
  include Her::Model
end
```

and api endpoint `/actors/:uid` returning

``` json
{
  "uid": "x1",
  "user": { "email": "x1@localhost" }
}
```

this 

``` ruby
Actor.find("x1").user.email # => "x1@localhost"
```

works well. But when adding `primary_key :uid` to `Actor` class

``` ruby
Actor.find("x1").user.email
# NoMethodError:
#       undefined method `email' for nil:NilClass
```

See the commit for failing spec.
