### PR TITLE
Don't attempt to persist invalid records

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -39,6 +39,8 @@ module Her
 
         run_callbacks callback do
           run_callbacks :save do
+            return false unless valid?(callback)
+
             params = to_params
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?

--- a/spec/model/validations_spec.rb
+++ b/spec/model/validations_spec.rb
@@ -20,6 +20,13 @@ describe "Her::Model and ActiveModel::Validations" do
       user.email = "tobias@bluthcompany.com"
       user.should be_valid
     end
+
+    it "validates attributes when calling #save" do
+      user = Foo::User.new
+      user.save.should be_false
+      user.errors.full_messages.should include("Fullname can't be blank")
+      user.errors.full_messages.should include("Email can't be blank")
+    end
   end
 
   context "handling server errors" do


### PR DESCRIPTION
This change adds running validation before attempting to save a record.
Before that, any validations from the model were ignored when saving.
