### PR TITLE
Set the ActiveModel::Dirty #changed_attributes and #previous_changes correctly.

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -25,7 +25,6 @@ module Her
 
         attributes = self.class.default_scope.apply_to(attributes)
         assign_attributes(attributes)
-        @changed_attributes = {}
         run_callbacks :initialize
       end
 

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -95,6 +95,7 @@ module Her
           @parent.request(request_params) do |parsed_data, response|
             if response.success?
               resource = @parent.new_from_parsed_data(parsed_data)
+              resource.instance_variable_set(:@changed_attributes, {})
               resource.run_callbacks :find
             else
               return nil

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -58,9 +58,8 @@ describe "Her::Model and ActiveModel::Dirty" do
 
     context "for new resource" do
       let(:user) { Foo::User.new(:fullname => "Lindsay Fünke") }
-      it "has no changes" do
-        user.changes.should be_empty
-        user.should_not be_changed
+      it "has changes" do
+        user.should be_changed
       end
       it "tracks dirty attributes" do
         user.fullname = "Tobias Fünke"


### PR DESCRIPTION
A new Her::Model object will now not show as dirty when instantiated.  Also, a #save call on a Her::Model will populate previous_changes.
