### PR TITLE
Remove redefined “respond_to?” method

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -78,11 +78,6 @@ module Her
       end
 
       # @private
-      def respond_to?(method, include_private = false)
-        method.to_s.end_with?('=') || method.to_s.end_with?('?') || @attributes.include?(method) || super
-      end
-
-      # @private
       def respond_to_missing?(method, include_private = false)
         method.to_s.end_with?('=') || method.to_s.end_with?('?') || @attributes.include?(method) || super
       end


### PR DESCRIPTION
Fixes #171 

Not sure why we ended up having a custom `respond_to?` method with the exact same content as our `respond_to_missing?`.

I don’t think we need it.
