### PR TITLE
Add `_ids` has_many association array

### DIFF
--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -21,6 +21,19 @@ module Her
               cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
               cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasManyAssociation.new(self, #{opts.inspect}))
             end
+
+            def #{name.to_s.singularize}_ids
+              cached_name = :"@_her_association_#{name.to_s.singularize}_ids"
+
+              cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
+              cached_data || instance_variable_set(cached_name, Array.new)
+            end
+
+            def #{name.to_s.singularize}_ids=(array)
+              cached_name = :"@_her_association_#{name.to_s.singularize}_ids"
+
+              instance_variable_set(cached_name, array)
+            end
           RUBY
         end
 

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -87,7 +87,7 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :comments => [{ :comment => { :id => 2, :body => "Tobias, you blow hard!", :user_id => 1 } }, { :comment => { :id => 3, :body => "I wouldn't mind kissing that man between the cheeks, so to speak", :user_id => 1 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 1, :name => "Bluth Company" }, :organization_id => 1 }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :comments => [{ :comment => { :id => 2, :body => "Tobias, you blow hard!", :user_id => 1 } }, { :comment => { :id => 3, :body => "I wouldn't mind kissing that man between the cheeks, so to speak", :user_id => 1 } }], :comment_ids => [2, 3], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 1, :name => "Bluth Company" }, :organization_id => 1 }.to_json] }
           stub.get("/users/2") { |env| [200, {}, { :id => 2, :name => "Lindsay Fünke", :organization_id => 2 }.to_json] }
           stub.get("/users/1/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }].to_json] }
           stub.get("/users/2/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?" } }].to_json] }
@@ -162,6 +162,13 @@ describe Her::Model::Associations do
 
     it "fetches has_many data even if it was included, only if called with parameters" do
       @user_with_included_data.comments.where(:foo_id => 1).length.should == 1
+    end
+
+    it "provides an array of has_many ids" do
+      @user_with_included_data.comment_ids.length.should == 2
+      @user_with_included_data.comment_ids.should == [2, 3]
+      @user_without_included_data.comment_ids.length.should == 0
+      @user_without_included_data.comment_ids.should == []
     end
 
     it "maps an array of included data through has_one" do

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -225,6 +225,44 @@ describe Her::Model::Parse do
     end
   end
 
+  context 'when associations are set' do
+    before do
+      Her::API.setup :url => "https://api.example.com" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.use Faraday::Request::UrlEncoded
+        builder.adapter :test do |stub|
+          stub.post("/users") { |env| [200, {}, { :id => 1, :first_name => "Tobias", :last_name => "Fünke" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { :id => 1, :first_name => "Tobias", :last_name => "Fünke", :post_ids => [1] }.to_json] }
+          stub.post("/posts") { |env| [200, {}, { :id => 1, :title => "The World's First Analrapist" }.to_json] }
+        end
+      end
+
+      spawn_model "Foo::Post" do
+        belongs_to :user
+        attributes :title
+      end
+
+      spawn_model "Foo::User" do
+        has_many :posts
+        attributes :first_name, :last_name
+      end
+    end
+
+    it "doesn't send associations in to_params" do
+      @user = Foo::User.create(:first_name => "Tobias", :last_name => "Fünke")
+      @post = Foo::Post.create(:title => "The World's First Analrapist", :user_id => @user.id)
+      expect(@user.to_params).to_not include(:posts)
+    end
+
+    it "includes association ids array in to_params" do
+      @user = Foo::User.create(:first_name => "Tobias", :last_name => "Fünke")
+      @post = Foo::Post.create(:title => "The World's First Analrapist", :user_id => @user.id)
+      @user = Foo::User.find(@user.id)
+      expect(@user.to_params).to include(:post_ids)
+      @user.to_params[:post_ids].should == [@post.id]
+    end
+  end
+
   context 'when send_only_modified_attributes is set' do
     before do
       Her::API.setup :url => "https://api.example.com", :send_only_modified_attributes => true do |builder|


### PR DESCRIPTION
**What**
This commit adds a getter and setter to has many associations for an `_ids` array. It returns this array in `to_params` and removes the association parameter.

**Why**
If you have a user who has many posts and you send a `posts` parameter, AR will throw a `ActiveRecord::AssociationTypeMismatch` because it's expecting an association when you're sending a hash. You can either, instead, send along `post_attributes` (to create the object and relationship) or `post_ids` (to create the relationship if the object already exists). The former was already present in Her; this commit adds the latter. This commit also avoids the AR error.

**How**
A getter and setter is defined when attaching a has many association. The list of attributes when requesting `to_params` is filtered to remove the association array and add the `_ids` array.

This PR includes passing tests and has been integrated into a production app. This problem was discussed in #153 and credit to @calmyournerves for the code and tests to filter out the association array.

**Example**
```ruby
class Post
  include Her::Model
  belongs_to :user

  attributes :title
end

class User
  include Her::Model
  has_many :posts

  attributes :name
end

@user = User.find(1)
@user.post_ids # => [0, 1, 5]
@user.post_ids = [0, 1, 5, 14]
@user.to_params # => { name: "Tobias Funke", post_ids: [0, 1, 5, 14] }
```