### PR TITLE
Fetch many instances by id on a single request.

### DIFF
--- a/lib/her/model/paths.rb
+++ b/lib/her/model/paths.rb
@@ -94,7 +94,7 @@ module Her
           unless path.is_a?(String)
             parameters = path.try(:with_indifferent_access) || parameters
             path =
-              if parameters.include?(primary_key) && parameters[primary_key]
+              if parameters.include?(primary_key) && parameters[primary_key] && !parameters[primary_key].kind_of?(Array)
                 resource_path.dup
               else
                 collection_path.dup

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -84,6 +84,7 @@ module Her
       #   # Fetched via GET "/users/1" and GET "/users/2"
       def find(*ids)
         params = @params.merge(ids.last.is_a?(Hash) ? ids.pop : {})
+        ids = Array(params[@parent.primary_key]) if params.key?(@parent.primary_key)
 
         results = ids.flatten.compact.uniq.map do |id|
           resource = nil

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -156,6 +156,7 @@ describe Her::Model::ORM do
         builder.adapter :test do |stub|
           stub.get("/users/1") { |env| [200, {}, { :id => 1, :age => 42 }.to_json] }
           stub.get("/users/2") { |env| [200, {}, { :id => 2, :age => 34 }.to_json] }
+          stub.get("/users?id[]=1&id[]=2") { |env| [200, {}, [{ :id => 1, :age => 42 }, { :id => 2, :age => 34 }].to_json] }
           stub.get("/users?age=42&foo=bar") { |env| [200, {}, [{ :id => 3, :age => 42 }].to_json] }
           stub.get("/users?age=42") { |env| [200, {}, [{ :id => 1, :age => 42 }].to_json] }
           stub.get("/users?age=40") { |env| [200, {}, [{ :id => 1, :age => 40 }].to_json] }
@@ -193,6 +194,22 @@ describe Her::Model::ORM do
       @users.should be_kind_of(Array)
       @users.length.should == 1
       @users[0].id.should == 1
+    end
+
+    it "handles finding by an array id param of length 2" do
+      @users = User.find(id: [1, 2])
+      @users.should be_kind_of(Array)
+      @users.length.should == 2
+      @users[0].id.should == 1
+      @users[1].id.should == 2
+    end
+
+    it 'handles finding with id parameter as an array' do
+      @users = User.where(id: [1, 2])
+      @users.should be_kind_of(Array)
+      @users.length.should == 2
+      @users[0].id.should == 1
+      @users[1].id.should == 2
     end
 
     it "handles finding with other parameters" do


### PR DESCRIPTION
Some times you'd like to find many instances by id with a single request. Using `where(id: [1, 2])` is most likely the way rails people would try to do this.

So I just fixed Her to treat `id` as yet another request param if its value turns out to be an array.
