### PR TITLE
Allow middlewares to return hash with String keys.

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -163,6 +163,7 @@ module Her
         #
         # @private
         def new_from_parsed_data(parsed_data)
+          parsed_data = parsed_data.with_indifferent_access
           new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
         end
 


### PR DESCRIPTION
I'm using FaradayMiddleware::Caching as suggested in #99. However FaradayMiddleware::Caching seems to return cached data with String keys. This cause her to throw nil errors.
