### PR TITLE
New can take existing objects

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -21,7 +21,11 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          { association[:name] => klass.new(data[data_key]) }
+          if data[data_key].kind_of?(klass)
+            { association[:name] => data[data_key] }
+          else
+            { association[:name] => klass.new(data[data_key]) }
+          end
         end
 
         # @private

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -33,8 +33,12 @@ module Her
       # @private
       def self.initialize_collection(klass, parsed_data={})
         collection_data = klass.extract_array(parsed_data).map do |item_data|
-          resource = klass.new(klass.parse(item_data))
-          resource.run_callbacks :find
+          if item_data.kind_of?(klass)
+            resource = item_data
+          else
+            resource = klass.new(klass.parse(item_data))
+            resource.run_callbacks :find
+          end
           resource
         end
         Her::Collection.new(collection_data, parsed_data[:metadata], parsed_data[:errors])

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -329,5 +329,18 @@ describe Her::Model::Associations do
         @user.comments.should == [@comment]
       end
     end
+
+    context "with #new" do
+      it "creates nested models from hash attibutes" do
+        user = Foo::User.new(:name => "vic", :comments => [{:text => "hello"}])
+        user.comments.first.text.should == "hello"
+      end
+
+      it "assigns nested models if given as already constructed objects" do
+        bye = Foo::Comment.new(:text => "goodbye")
+        user = Foo::User.new(:name => 'vic', :comments => [bye])
+        user.comments.first.text.should == 'goodbye'
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey guys, 

I've been using her a lot lately. However I've got to find some minor unexpected `her` behaviours
(at least for the common rails user).

One of these was that trying to create an instance with an already instantiated associated object like:

``` ruby
   organization = Organization.new # somehow it was created or fetched before

   user = User.new(organization: organization)
```

was yielding an unpleasent `undefined method delete on instance of Organization` error.

I made a minor change to the association code which builds the instances to check if the given objects
are already a kind of the associated class, in which case we dont need to create a new instance but
just assign the attribute.
