### PR TITLE
Forward *almost* all methods to the fetched object.

### DIFF
--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -1,4 +1,5 @@
 require "her/model/associations/association"
+require "her/model/associations/association_proxy"
 require "her/model/associations/belongs_to_association"
 require "her/model/associations/has_many_association"
 require "her/model/associations/has_one_association"

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -16,6 +16,11 @@ module Her
         end
 
         # @private
+        def self.proxy(parent, opts = {})
+          AssociationProxy.new new(parent, opts)
+        end
+
+        # @private
         def self.parse_single(association, klass, data)
           data_key = association[:data_key]
           return {} unless data[data_key]
@@ -66,7 +71,7 @@ module Her
         #   user.comments.where(:approved => 1) # Fetched via GET "/users/1/comments?approved=1
         def where(params = {})
           return self if params.blank? && @parent.attributes[@name].blank?
-          self.clone.tap { |a| a.params = a.params.merge(params) }
+          AssociationProxy.new self.clone.tap { |a| a.params = a.params.merge(params) }
         end
         alias all where
 
@@ -86,37 +91,6 @@ module Her
           @klass.get(path, @params)
         end
 
-        # @private
-        def nil?
-          fetch.nil?
-        end
-
-        # @private
-        def empty?
-          fetch.empty?
-        end
-
-        # @private
-        def kind_of?(thing)
-          fetch.kind_of?(thing)
-        end
-
-        # @private
-        def ==(other)
-          fetch.eql?(other)
-        end
-        alias eql? ==
-
-        # ruby 1.8.7 compatibility
-        # @private
-        def id
-          fetch.id
-        end
-
-        # @private
-        def method_missing(method, *args, &blk)
-          fetch.send(method, *args, &blk)
-        end
       end
     end
   end

--- a/lib/her/model/associations/association_proxy.rb
+++ b/lib/her/model/associations/association_proxy.rb
@@ -1,0 +1,46 @@
+module Her
+  module Model
+    module Associations
+      class AssociationProxy < ActiveSupport::BasicObject
+
+        # @private
+        def self.install_proxy_methods(target_name, *names)
+          names.each do |name|
+            module_eval <<-RUBY, __FILE__, __LINE__ + 1
+              def #{name}(*args, &block)
+                #{target_name}.#{name}(*args, &block)
+              end
+            RUBY
+          end
+        end
+
+        install_proxy_methods :association,
+          :build, :create, :where, :find, :all, :assign_nested_attributes
+
+        # @private
+        def initialize(association)
+          @_her_association = association
+        end
+
+        def association
+          @_her_association
+        end
+
+        # @private
+        def method_missing(name, *args, &block)
+          if :object_id == name # avoid redefining object_id
+            return association.fetch.object_id
+          end
+
+          # create a proxy to the fetched object's method
+          metaclass = (class << self; self; end)
+          metaclass.install_proxy_methods 'association.fetch', name
+
+          # resend message to fetched object
+          __send__(name, *args, &block)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -2,6 +2,7 @@ module Her
   module Model
     module Associations
       class BelongsToAssociation < Association
+
         # @private
         def self.attach(klass, name, opts)
           opts = {
@@ -19,7 +20,7 @@ module Her
               cached_name = :"@_her_association_#{name}"
 
               cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
-              cached_data || instance_variable_set(cached_name, Her::Model::Associations::BelongsToAssociation.new(self, #{opts.inspect}))
+              cached_data || instance_variable_set(cached_name, Her::Model::Associations::BelongsToAssociation.proxy(self, #{opts.inspect}))
             end
           RUBY
         end

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -2,6 +2,7 @@ module Her
   module Model
     module Associations
       class HasManyAssociation < Association
+
         # @private
         def self.attach(klass, name, opts)
           opts = {
@@ -19,7 +20,7 @@ module Her
               cached_name = :"@_her_association_#{name}"
 
               cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
-              cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasManyAssociation.new(self, #{opts.inspect}))
+              cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasManyAssociation.proxy(self, #{opts.inspect}))
             end
           RUBY
         end

--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -2,6 +2,7 @@ module Her
   module Model
     module Associations
       class HasOneAssociation < Association
+
         # @private
         def self.attach(klass, name, opts)
           opts = {
@@ -18,7 +19,7 @@ module Her
               cached_name = :"@_her_association_#{name}"
 
               cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
-              cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasOneAssociation.new(self, #{opts.inspect}))
+              cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasOneAssociation.proxy(self, #{opts.inspect}))
             end
           RUBY
         end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -184,6 +184,7 @@ module Her
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
               unless instance_methods.include?(:'#{attribute}=')
                 def #{attribute}=(value)
+                  @attributes[:'#{attribute}'] = nil unless @attributes.include?(:'#{attribute}')
                   self.send(:"#{attribute}_will_change!") if @attributes[:'#{attribute}'] != value
                   @attributes[:'#{attribute}'] = value
                 end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -146,11 +146,11 @@ describe Her::Model::Associations do
     end
 
     it "does not refetch the parents models data if they have been fetched before" do
-      @user_with_included_data.comments.first.user.fetch.object_id.should == @user_with_included_data.object_id
+      @user_with_included_data.comments.first.user.object_id.should == @user_with_included_data.object_id
     end
 
     it "uses the given inverse_of key to set the parent model" do
-      @user_with_included_data.posts.first.admin.fetch.object_id.should == @user_with_included_data.object_id
+      @user_with_included_data.posts.first.admin.object_id.should == @user_with_included_data.object_id
     end
 
     it "fetches data that was not included through has_many" do


### PR DESCRIPTION
It was somewhat weird that `her` association methods returned an object that in some cases masked some of
the methods defined by Object / Kernel instead of delegating them to the fetched value.

Suppose you had a relation where a `User` has one `Role`. After fetching the `user` object along with
it's associated role, if you did called `class` on it

``` ruby
  user.role.class # => Her::Associations::HasOneAssociation
```

returned the association class instead of the most likely expected `Role` class. This happened with
almost any method defined on Object, for example:

``` ruby
  module M
    def m
      1
    end
  end

  role = Role.new
  user = User.new
  user.role = role

  user.role.extend M
  role.kind_of?(M) # => false but should have to be true
```

In the previous example, extending the value returned by `user.role` was actually extending
the `association` object instead of the actual role object.

Some other unfortunate effects of the way it used to be was that calling `user.role.to_json`
was trying to serialize the relation object along all it's metadata (params, parent, etc)
instead of the role object.

So I think that instead of having `her` users to think about explicitly doing `.fetch` for
their code to work, why not making it work as they should actually expect from any other
library like active record.

The way I approached this was by making the association method to return a BlankObject
(actually ActiveSupport::BlankObject) proxy that has _almost no method_ defined, and
thus it cannot mask methods you actually intended to call on the fetched object.
So all methods on this proxy are forwarded to the fetched object, except for a handful
of them like `where`, `find`, etc, which get called on the association.

One important thing to notice is that I intentionally left out the `fetch` method
from the methods defined on the proxy. But I added an `association` one which
returns the association object upon which you can still call fetch, if you'd ever
need to `user.role.association.fetch`.

I consider the `fetch` method should not not be directly defined on the proxy as
no one should actually need to manually call it (as you never do with activerecord
to retrieve objects from the database). And if you do _need_ to call `fetch`
explicitely, then I guess you are in that case aware you're working with an
non-active-record thingy but a `her` one. That's why you can still do `association.fetch`.

So this have been a quite large commit message, but I hope it explains why
I decided to spend a day fixing this on `her`, in the hope of avoiding others
the hard times I got this week while finding these unexpected behaviours.

Besides all, thanks for making `her` it's such an awesome library.
