### PR TITLE
Save a reference to fetched has one relationships.

### DIFF
--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -17,7 +17,6 @@ module Her
           klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}
               cached_name = :"@_her_association_#{name}"
-
               cached_data = (instance_variable_defined?(cached_name) && instance_variable_get(cached_name))
               cached_data || instance_variable_set(cached_name, Her::Model::Associations::HasOneAssociation.proxy(self, #{opts.inspect}))
             end
@@ -67,6 +66,18 @@ module Her
           resource = build(attributes)
           @parent.attributes[@name] = resource if resource.save
           resource
+        end
+
+        # If we have already loaded this assocation we do not need to refetch
+        # it.
+        #
+        # @private
+        def fetch(opts = {})
+          @has_one_relationships ||= Hash.new do |h, key|
+            h[key] = super
+          end
+
+          @has_one_relationships[@params]
         end
 
         # @private


### PR DESCRIPTION
Currently has_one relationships are fetched everytime a message is sent
to the proxy. This commit adds a has_one cache that prevents the proxy
from fetching a new record if it has already fetched model with the
current params.

I added specs that show the behavior I am trying to accomplish. I think
the specs are straight forward, but if you run the against master they
will fail.