### PR TITLE
fix belongs to association load when using active model serializers

### DIFF
--- a/her.gemspec
+++ b/her.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activemodel", ">= 3.0.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0"
-  s.add_runtime_dependency "faraday", "~> 0.8"
+  s.add_runtime_dependency "faraday", "~> 0.8.9"
   s.add_runtime_dependency "multi_json", "~> 1.7"
 end

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -79,7 +79,7 @@ module Her
           if @parent.attributes[@name].blank? || @params.any?
             path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
             path = build_association_path lambda { @klass.build_request_path(path_params) }
-            @klass.get(path, @params)
+            @klass.get_resource(path, @params)
           else
             @parent.attributes[@name]
           end


### PR DESCRIPTION
Belongs to does not work when using active model serializer format for models.