### PR TITLE
Add support for dash attributes on a model

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -185,21 +185,19 @@ module Her
           attributes.each do |attribute|
             attribute = attribute.to_sym
 
-            class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              unless instance_methods.include?(:'#{attribute}=')
-                def #{attribute}=(value)
-                  @attributes[:'#{attribute}'] = nil unless @attributes.include?(:'#{attribute}')
-                  self.send(:"#{attribute}_will_change!") if @attributes[:'#{attribute}'] != value
-                  @attributes[:'#{attribute}'] = value
-                end
+            unless instance_methods.include?(:"#{attribute}=")
+              define_method("#{attribute}=") do |value|
+                @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")
+                self.send(:"#{attribute}_will_change!") if @attributes[:'#{attribute}'] != value
+                @attributes[:"#{attribute}"] = value
               end
+            end
 
-              unless instance_methods.include?(:'#{attribute}?')
-                def #{attribute}?
-                  @attributes.include?(:'#{attribute}') && @attributes[:'#{attribute}'].present?
-                end
+            unless instance_methods.include?(:"#{attribute}?")
+              define_method("#{attribute}?") do
+                @attributes.include?(:"#{attribute}") && @attributes[:"#{attribute}"].present?
               end
-            RUBY
+            end
           end
         end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -59,6 +59,12 @@ describe Her::Model::Attributes do
       @new_user.get_attribute(:unknown_method_for_a_user).should be_nil
       @new_user.get_attribute(:fullname).should == 'Mayonegg'
     end
+
+    it "handles get_attribute for getter with dash" do
+      @new_user = Foo::User.new(:'life-span' => '3 years')
+      @new_user.get_attribute(:unknown_method_for_a_user).should be_nil
+      @new_user.get_attribute(:'life-span').should == '3 years'
+    end
   end
 
 

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -40,6 +40,11 @@ describe Her::Model::Introspection do
         @user.inspect.should include("password=\"filtered\"")
         @user.inspect.should_not include("password=\"Funke\"")
       end
+
+      it "support dash on attribute" do
+        @user = Foo::User.new(:'life-span' => "3 years")
+        @user.inspect.should include("life-span=\"3 years\"")
+      end
     end
 
     describe "#inspect with errors in resource path" do


### PR DESCRIPTION
Fix for this issue: #205

By using `define_method`, we can use dash in an attribute name.
