### PR TITLE
Fix readme examples for custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Resources must always have all the required attributes to build their complete p
 ```ruby
 class User
   include Her::Model
-  collection_path "organizations/:organization_id/users"
+  resource_path "organizations/:organization_id/users"
 end
 
 class Organization
@@ -661,7 +661,7 @@ end
 # GET "/utilisateur/1"
 ```
 
-### Custom ressources paths
+### Custom resources paths
 
 You can define custom HTTP paths for your models:
 
@@ -766,7 +766,7 @@ A neat trick you can do with scopes is interact with complex paths.
 class User
   include Her::Model
 
-  collection_path "organizations/:organization_id/users"
+  resource_path "organizations/:organization_id/users"
   scope :for_organization, -> { |id| where(organization_id: id) }
 end
 

--- a/README.md
+++ b/README.md
@@ -647,14 +647,28 @@ User.get("/users/popular")
 # => [#<User id=1>, #<User id=2>]
 ```
 
-### Custom paths
+### Custom base path
+
+You can change the base HTTP path for your models:
+
+```ruby
+class User
+  include Her::Model
+  collection_path "/utilisateur"
+end
+
+@user = User.find(1)
+# GET "/utilisateur/1"
+```
+
+### Custom ressources paths
 
 You can define custom HTTP paths for your models:
 
 ```ruby
 class User
   include Her::Model
-  collection_path "/hello_users/:id"
+  resource_path "/hello_users/:id"
 end
 
 @user = User.find(1)
@@ -666,7 +680,7 @@ You can also include custom variables in your paths:
 ```ruby
 class User
   include Her::Model
-  collection_path "/organizations/:organization_id/users"
+  resource_path "/organizations/:organization_id/users"
 end
 
 @user = User.find(1, _organization_id: 2)


### PR DESCRIPTION
I was trying to get the custom paths working using the `collection_path` attribute. This feature looked broken (#231) but I think it's just the README that is out of date. I looked at [the code](https://github.com/remiprev/her/blob/master/lib/her/model/paths.rb#L41-L86) and found that `collection_path` should only change the base path with no attributes and that `resource_path` can take attributes. 

This PR changes the README examples by changing `collection_path` to `resource_path` where required and also adds an example for changing the base path using the `collection_path` attribute.

Also, I'm not so sure why [these tests are passing](https://github.com/remiprev/her/blob/master/spec/model/paths_spec.rb#L30-L47). With my test script and as pointed out in #231 I don't think they should work.   