### PR TITLE
Always return a hash when building the associations

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -66,7 +66,7 @@ module Her
               hash[association[:data_key]] = params
             end
             hash
-          end
+          end || {}
         end
 
         # Return or change the value of `include_root_in_json`


### PR DESCRIPTION
allows us to merge! the filtered attributes (in #to_params) without raising an exception if a has_many relation value is an empty array
