### PR TITLE
default @response_error to empty array

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -42,8 +42,8 @@ module Her
             params = to_params
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
-              @metadata = parsed_data[:metadata]
-              @response_errors = parsed_data[:errors]
+              @metadata = parsed_data[:metadata] || {}
+              @response_errors = parsed_data[:errors] || {}
 
               return false if !response.success? || @response_errors.any?
               if self.changed_attributes.present?
@@ -76,8 +76,8 @@ module Her
         run_callbacks :destroy do
           self.class.request(:_method => method, :_path => request_path) do |parsed_data, response|
             assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
-            @metadata = parsed_data[:metadata]
-            @response_errors = parsed_data[:errors]
+            @metadata = parsed_data[:metadata] || {}
+            @response_errors = parsed_data[:errors] || {}
             @destroyed = true
           end
         end


### PR DESCRIPTION
In the api which I am integrating with HER, if errors field is empty (api doesn't return any error fields), we want to default the errors and default metadata fields to empty array. 
