### PR TITLE
Handle hash with string keys returned from faraday-http-cache

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -103,7 +103,7 @@ module Her
         end
       end
 
-      { :parsed_data => response.env[:body], :response => response }
+      { :parsed_data => response.env[:body].symbolize_keys, :response => response }
     end
 
     private

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -32,7 +32,6 @@ module Her
       #
       # @private
       def self.initialize_collection(klass, parsed_data={})
-        parsed_data = parsed_data.with_indifferent_access
         collection_data = klass.extract_array(parsed_data).map do |item_data|
           if item_data.kind_of?(klass)
             resource = item_data
@@ -172,7 +171,6 @@ module Her
         #
         # @private
         def new_from_parsed_data(parsed_data)
-          parsed_data = parsed_data.with_indifferent_access
           new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
         end
 

--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -91,6 +91,7 @@ module Her
             def #{method}_resource(path, params={})
               path = build_request_path_from_string_or_symbol(path, params)
               send(:"#{method}_raw", path, params) do |parsed_data, response|
+
                 new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
               end
             end

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -41,8 +41,6 @@ module Her
           run_callbacks :save do
             params = to_params
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
-              parsed_data = parsed_data.with_indifferent_access
-
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
               @metadata = parsed_data[:metadata]
               @response_errors = parsed_data[:errors]

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -170,7 +170,7 @@ describe Her::Model::ORM do
 
     it "handles metadata on a collection" do
       @users = User.all
-      @users.metadata[:total_pages].should == 10
+      @users.metadata['total_pages'].should == 10
     end
 
     it "handles error data on a collection" do
@@ -180,7 +180,7 @@ describe Her::Model::ORM do
 
     it "handles metadata on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.metadata[:foo].should == "bar"
+      @user.metadata['foo'].should == "bar"
     end
 
     it "handles error data on a resource" do


### PR DESCRIPTION
I'm using [faraday-http-cache](https://github.com/plataformatec/faraday-http-cache) with Redis but the parsed JSON hash return from the cache is not symbolised and caused Her to throw Nil errors. #192 does not fix all the problems.
