### PR TITLE
Cache subsequent calls with parameters when accesssing assosiation objects

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -12,6 +12,7 @@ module Her
           @params = {}
 
           @klass = @parent.class.her_nearby_class(@opts[:class_name])
+          @cached_result = {}
           @name = @opts[:name]
         end
 
@@ -47,12 +48,12 @@ module Her
           attribute_value = @parent.attributes[@name]
           return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && (attribute_value.nil? || !attribute_value.nil? && attribute_value.empty?) && @params.empty?
 
-          return @cached_result if @params.blank? && @cached_result
+          return @cached_result[@params] if @cached_result[@params].present?
           return @parent.attributes[@name] if @params.blank? && @parent.attributes[@name].present?
 
           path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}" }
           @klass.get(path, @params).tap do |result|
-            @cached_result = result if @params.blank?
+            @cached_result[@params] = result
           end
         end
 

--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -47,12 +47,12 @@ module Her
           attribute_value = @parent.attributes[@name]
           return @opts[:default].try(:dup) if @parent.attributes.include?(@name) && (attribute_value.nil? || !attribute_value.nil? && attribute_value.empty?) && @params.empty?
 
-          return @cached_result unless @params.any? || @cached_result.nil?
-          return @parent.attributes[@name] unless @params.any? || @parent.attributes[@name].blank?
+          return @cached_result if @params.blank? && @cached_result
+          return @parent.attributes[@name] if @params.blank? && @parent.attributes[@name].present?
 
           path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}" }
           @klass.get(path, @params).tap do |result|
-            @cached_result = result unless @params.any?
+            @cached_result = result if @params.blank?
           end
         end
 

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -76,13 +76,13 @@ module Her
           data_key_value = @parent.attributes[@opts[:data_key].to_sym]
           return @opts[:default].try(:dup) if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @params.empty?) || (@parent.persisted? && foreign_key_value.blank? && data_key_value.blank?)
 
-          return @cached_result if @params.present? && @cached_result
+          return @cached_result[@params] if @cached_result[@params].present?
           return @parent.attributes[@name] if @params.blank? && @parent.attributes[@name].present?
 
           path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
           path = build_association_path lambda { @klass.build_request_path(path_params) }
           @klass.get(path, @params).tap do |result|
-            @cached_result = result if @params.blank?
+            @cached_result[@params] = result
           end
         end
 

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -76,8 +76,8 @@ module Her
           data_key_value = @parent.attributes[@opts[:data_key].to_sym]
           return @opts[:default].try(:dup) if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @params.empty?) || (@parent.persisted? && foreign_key_value.blank? && data_key_value.blank?)
 
-          return @cached_result unless @params.any? || @cached_result.nil?
-          return @parent.attributes[@name] unless @params.any? || @parent.attributes[@name].blank?
+          return @cached_result if @params.present? && @cached_result
+          return @parent.attributes[@name] if @params.blank? && @parent.attributes[@name].present?
 
           path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
           path = build_association_path lambda { @klass.build_request_path(path_params) }

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -158,6 +158,14 @@ describe Her::Model::Associations do
       comment_without_included_parent_data.user.object_id.should_not == comment_without_included_parent_data.user.where(:a => 2).object_id
     end
 
+    it "does not refetch the parent models data if parameters are identical" do
+      comment_without_included_parent_data.user.where(:a => 1).object_id.should == comment_without_included_parent_data.user.where(:a => 1).object_id
+    end
+
+    it "does fetch the parent models data if parameters are not identical" do
+      comment_without_included_parent_data.user.where(:a => 1).object_id.should_not == comment_without_included_parent_data.user.where(:a => 2).object_id
+    end
+
     it "uses the given inverse_of key to set the parent model" do
       @user_with_included_data.posts.first.admin.object_id.should == @user_with_included_data.object_id
     end
@@ -179,6 +187,14 @@ describe Her::Model::Associations do
 
     it "fetches data that was cached through has_many if called with parameters" do
       @user_without_included_data.comments.first.object_id.should_not == @user_without_included_data.comments.where(:foo_id => 1).first.object_id
+    end
+
+    it "does not fetch data that was cached through has_many if called parameters are identical" do
+      @user_without_included_data.comments.where(:foo_id => 1).first.object_id.should == @user_without_included_data.comments.where(:foo_id => 1).first.object_id
+    end
+
+    it "does fetch data that was cached through has_many if called parameters are not identical" do
+      @user_without_included_data.comments.where(:id => 4).first.object_id.should_not == @user_without_included_data.comments.where(:foo_id => 1).first.object_id
     end
 
     it "maps an array of included data through has_one" do


### PR DESCRIPTION
### Changes

Change `@cached_result` type to a Hash, and use `@params` as hash key to store the value.

Based on this pull request: https://github.com/remiprev/her/issues/248

### Real World Example

When I apply pagination parameter to the association objects, I found that the request was not cached and will be triggered every time it's been called.

```ruby
@posts = @user.posts.where(page: params[:page])

@posts # => Fire a request
@posts # => Fire a request
@posts # => Fire a request
```

By using memcache the requests will still be sent, even though since 2nd time memcache will return the cached value.

---

Not sure if it has any undesirable side effect, I've checked that all specs are passed on my local.