### PR TITLE
Remove apparently useless next clause in #embedded_params causing method to return nil

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -58,7 +58,7 @@ module Her
         def embeded_params(attributes)
           associations[:has_many].select { |a| attributes.include?(a[:data_key])}.compact.inject({}) do |hash, association|
             params = attributes[association[:data_key]].map(&:to_params)
-            if association[:class_name].constantize.include_root_in_json?
+            if her_nearby_class(association[:class_name]).include_root_in_json?
               root = association[:class_name].constantize.root_element
               hash[association[:data_key]] = params.map { |n| n[root] }
             else

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -364,4 +364,22 @@ describe Her::Model::Parse do
     end
   end
 
+  context 'parsing an association of a class in a module'
+    before do
+      Her::API.setup :url => "https://api.example.com", :send_only_modified_attributes => true do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.use Faraday::Request::UrlEncoded
+      end
+
+      spawn_model "Foo::User" do
+        has_many :pets
+      end
+      spawn_model "Foo::Pet"
+    end
+
+    subject { Foo::User.build(fullname: "Tobias Fünke", pets: []) }
+
+    it 'should not raise an error while trying to parse to params' do
+      expect{ subject.to_params }.to_not raise_error
+    end
 end


### PR DESCRIPTION
This fixes an issue where if a Her model, with a `has_many` association was _built_ with an empty array for said association, that an error would be raised when `#to_params` was called on that object.

The root of this problem was a `next` clause in the middle of an `#inject` (which causes the memo, formerly a hash, to become `nil`).

Regardless, it didn't seem to me that the `next` clause was accomplishing anything.  An association skipped here because it was blank would still be included in the `#to_params` result because it was being merged with the existing params.  Removing the offending clause did not break any current specs.

Also a ninja bug fix to use `#her_nearby_class` to determine the class to call `#include_root_in_json`.
