### PR TITLE
Use `#send` in `.install_proxy_methods`

### DIFF
--- a/lib/her/model/associations/association_proxy.rb
+++ b/lib/her/model/associations/association_proxy.rb
@@ -8,7 +8,7 @@ module Her
           names.each do |name|
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{name}(*args, &block)
-                #{target_name}.#{name}(*args, &block)
+                #{target_name}.send(#{name.inspect}, *args, &block)
               end
             RUBY
           end

--- a/spec/model/associations/association_proxy_spec.rb
+++ b/spec/model/associations/association_proxy_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "spec_helper"
 
 describe Her::Model::Associations::AssociationProxy do

--- a/spec/model/associations/association_proxy_spec.rb
+++ b/spec/model/associations/association_proxy_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe Her::Model::Associations::AssociationProxy do
+  describe "proxy assignment methods" do
+    before do
+      Her::API.setup url: "https://api.example.com" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.use Faraday::Request::UrlEncoded
+        builder.adapter :test do |stub|
+          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json ] }
+          stub.get("/users/1/fish") { |env| [200, {}, { :id => 1, :name => "Tobias's Fish" }.to_json ] }
+        end
+      end
+      spawn_model "User" do
+        has_one :fish
+      end
+      spawn_model "Fish"
+    end
+
+    subject { User.find(1) }
+
+    it "should assign value" do
+      subject.fish.name = "Fishy"
+      expect(subject.fish.name).to eq "Fishy"
+    end
+  end
+end
+
+
+


### PR DESCRIPTION
# Why?
Old approach would raise a syntax error in the for `method_missing`/`.install_proxy_methods` for such assignment methods.

# What?
In order to proxy syntactic sugar methods (e.g. some_attribute=), use `#send` in the module_eval.  