### PR TITLE
avoid exception when saving empty associations

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -58,7 +58,7 @@ module Her
         def embeded_params(attributes)
           associations[:has_many].select { |a| attributes.include?(a[:data_key])}.compact.inject({}) do |hash, association|
             params = attributes[association[:data_key]].map(&:to_params)
-            next if params.empty?
+            next {} if params.empty?
             if association[:class_name].constantize.include_root_in_json?
               root = association[:class_name].constantize.root_element
               hash[association[:data_key]] = params.map { |n| n[root] }

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -400,6 +400,27 @@ describe Her::Model::Associations do
       end
     end
 
+    context "with #save and association having an empty array" do
+      before do
+        Her::API.setup :url => "https://api.example.com" do |builder|
+          builder.use Her::Middleware::FirstLevelParseJSON
+          builder.use Faraday::Request::UrlEncoded
+          builder.adapter :test do |stub|
+            stub.get("/users/10") { |env| [200, {}, { :id => 10, comments: [] }.to_json] }
+            stub.put("/users/10") { |env| [200, {}] }
+          end
+        end
+
+        Foo::User.use_api Her::API.default_api
+      end
+
+      it "successfuly saves the record" do
+        @user = Foo::User.find(10)
+        @user.save
+        @user.comments.should == []
+      end
+    end
+
     context "with #new" do
       it "creates nested models from hash attibutes" do
         user = Foo::User.new(:name => "vic", :comments => [{:text => "hello"}])


### PR DESCRIPTION
As mentioned in https://github.com/remiprev/her/issues/245 `her` seems to raise an exception when trying to save an object that is based on a JSON response with empty arrays for the associations. The problem was that `next` would return nil and then crash when trying to merge the result with a hash in `to_params`.
