### PR TITLE
Ignore belongs_to relations when parsing params

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -34,6 +34,7 @@ module Her
         def to_params(attributes, changes={})
           filtered_attributes = attributes.dup.symbolize_keys
           filtered_attributes.merge!(embeded_params(attributes))
+          filtered_attributes.except!(*associations[:belongs_to].map{ |a| a[:data_key] })
           if her_api.options[:send_only_modified_attributes]
             filtered_attributes = changes.symbolize_keys.keys.inject({}) do |hash, attribute|
               hash[attribute] = filtered_attributes[attribute]


### PR DESCRIPTION
By convention, `belongs_to` relations are not parsed into the params; however in some contexts, the `belongs_to` `:data_key` might be set in `attributes`.  The `#to_params` method does not attempt to parse these attributes, and so, one ends up with a JSON body containing:

``` JSON
{
  ...
  "some_belongs_to_key":"#<SomeBelongsToKlass:0x00000005dfd388>",
  ...
}
```

This is extra noise through the pipe at best, and in our use, cause the resource server to complain and 400/500.

This fix, strips out any `belongs_to` `data_key` in the `attributes` when parsing params.
