### PR TITLE
Allow "super" to be called within overridden association methods

### DIFF
--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -135,6 +135,19 @@ module Her
         def belongs_to(name, opts={})
           Her::Model::Associations::BelongsToAssociation.attach(self, name, opts)
         end
+
+        # @private
+        def overridable_eval(*args)
+          module_name = :DynamicAssociations
+          if const_defined?(module_name, false)
+            mod = const_get(module_name)
+          else
+            mod = const_set(module_name, Module.new)
+            include mod
+          end
+          mod.module_eval(*args)
+        end
+
       end
     end
   end

--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -15,7 +15,7 @@ module Her
           }.merge(opts)
           klass.associations[:belongs_to] << opts
 
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          klass.overridable_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}
               cached_name = :"@_her_association_#{name}"
 

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -15,7 +15,7 @@ module Her
           }.merge(opts)
           klass.associations[:has_many] << opts
 
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          klass.overridable_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}
               cached_name = :"@_her_association_#{name}"
 

--- a/lib/her/model/associations/has_one_association.rb
+++ b/lib/her/model/associations/has_one_association.rb
@@ -14,7 +14,7 @@ module Her
           }.merge(opts)
           klass.associations[:has_one] << opts
 
-          klass.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          klass.overridable_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}
               cached_name = :"@_her_association_#{name}"
 


### PR DESCRIPTION
## Use case

It is sometimes useful to be able to extend the association methods that `has_many` et al dynamically generate. For example interacting with a users API that returns a `comment_count` cache, we can save an extra roundtrip to the API by shutting down requests for comments if the counter is 0. Simplified example:

```ruby
class User
  include Her::Model
  has_many :comments
  
  def comments
    return [] if comment_count <= 0
    super
  end
```

## The issue

Currently, defining a `comments` method will completely override the dynamically created version and when calling `super` raise the exception `no superclass method 'comments'`.

## The fix

Using [Avdi Grimm](https://gist.github.com/avdi/6123055) and [Henrik Nyh's](http://thepugautomatic.com/2013/07/dsom/) pattern of including the methods as a module allows us to override the dynamically generated methods and call super from within them, similar to how ActiveRecord works.