### PR TITLE
Not allow hash syntax setting

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -71,7 +71,7 @@ module Her
       #
       # @private
       def method_missing(method, *args, &blk)
-        if method.to_s =~ /[?=]$/ || @attributes.include?(method)
+        if method.to_s =~ /[^\[\]][?=]$/ || @attributes.include?(method)
           # Extract the attribute
           attribute = method.to_s.sub(/[?=]$/, '')
 
@@ -87,7 +87,7 @@ module Her
 
       # @private
       def respond_to_missing?(method, include_private = false)
-        method.to_s.end_with?('=') || method.to_s.end_with?('?') || @attributes.include?(method) || super
+        method.to_s =~ /[^\[\]][?=]$/ || method.to_s.end_with?('?') || @attributes.include?(method) || super
       end
 
       # Assign new attributes to a resource

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -65,6 +65,18 @@ describe Her::Model::Attributes do
       @new_user.get_attribute(:unknown_method_for_a_user).should be_nil
       @new_user.get_attribute(:'life-span').should == '3 years'
     end
+
+    it "does not try to handle hash syntax setter" do
+      @new_user = Foo::User.new
+      expect { @new_user[:fullname] = "Tobias Fünke" }.to_not raise_error(ArgumentError)
+      expect { @new_user[:fullname] = "Tobias Fünke" }.to raise_error(NoMethodError)
+    end
+
+    it "does not respond to hash syntax setter method" do
+      @new_user = Foo::User.new
+      expect(@new_user).to_not respond_to(:[]=)
+    end
+
   end
 
 


### PR DESCRIPTION
I was attempting to set an attribute on a Her model object using the hash syntax and came across a strange error

```
> subject[:some_attribute] = "bar" 
# => ArgumentError: wrong number of arguments (2 for 1) ... /lib/her/model/attributes.rb:193
```

Investigation revealed that Her was interpreting `[]` as a hash key, therefore the expected hash key was used as the value for the key `[]`.  This PR is a quick change that stops Her from using `[]` as a hash key with a setter.  
