### PR TITLE
don't crash if errors is a hash

### DIFF
--- a/lib/her/errors.rb
+++ b/lib/her/errors.rb
@@ -19,7 +19,14 @@ module Her
       attr_reader :resource
       def initialize(resource)
         @resource = resource
-        errors = @resource.response_errors.join(", ")
+
+        errors = @resource.response_errors.inspect
+        if @resource.response_errors.respond_to?(:join)
+          errors = @resource.response_errors.join(", ")
+        elsif @resource.response_errors.respond_to?(:flatten)
+          errors = @resource.response_errors.flatten.join(", ")
+        end
+
         super("Remote validation failed: #{errors}")
       end
     end

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -72,7 +72,7 @@ describe Her::Model::ORM do
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
           stub.get("/users") { |env| [200, {}, { :data => [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }], :metadata => { :total_pages => 10, :next_page => 2 }, :errors => ["Oh", "My", "God"] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :data => { :name => "George Michael Bluth" }, :metadata => { :foo => "bar" }, :errors => ["Yes", "Sir"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { :data => { :name => "George Michael Bluth" }, :metadata => { :foo => "bar" }, :errors => { :name => "Is Too Silly" }}.to_json] }
         end
       end
 
@@ -98,7 +98,7 @@ describe Her::Model::ORM do
 
     it "handles error data on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.response_errors.should == ["Yes", "Sir"]
+      @user.response_errors.should == { :name => "Is Too Silly" }
     end
   end
 
@@ -307,12 +307,14 @@ describe Her::Model::ORM do
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
           stub.post("/users") { |env| [200, {}, { :id => 1, :fullname => Faraday::Utils.parse_query(env[:body])['fullname'], :email => Faraday::Utils.parse_query(env[:body])['email'] }.to_json] }
-          stub.post("/companies") { |env| [200, {}, { :errors => ["name is required"] }.to_json] }
+          stub.post("/companies") { |env| [200, {}, { :errors => [ "name is required" ] }.to_json] }
+          stub.post("/managers") { |env| [200, {}, { :errors => { :name => "name is required" } }.to_json] }
         end
       end
 
       spawn_model "Foo::User"
       spawn_model "Foo::Company"
+      spawn_model "Foo::Manager"
     end
 
     it "handle one-line resource creation" do
@@ -342,6 +344,11 @@ describe Her::Model::ORM do
     it "raises ResourceInvalid when #save! gets errors" do
       @company = Foo::Company.new
       expect { @company.save! }.to raise_error Her::Errors::ResourceInvalid, "Remote validation failed: name is required"
+    end
+
+    it "raises ResourceInvalid with flattened hash when #save! gets errors" do
+      @manager = Foo::Manager.new
+      expect { @manager.save! }.to raise_error Her::Errors::ResourceInvalid, "Remote validation failed: name, name is required"
     end
 
     it "don't overwrite data if response is empty" do


### PR DESCRIPTION
I was using Her with an API that returns a hash for errors instead of an array:

```
[2] pry(#<Her::Errors::ResourceInvalid>)> @resource.response_errors
=> {:param1=>["can't be blank"], :base=>["duplicate enrollment pending"]}
```

lib/her/errors.rb crashed on .join() being undefined