### PR TITLE
Wrap parsed data which maintains backwards compatibility for apis that r...

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,7 +594,7 @@ class User
 end
 
 user = Users.find(1)
-# GET "/users/1", response is { "users": [{ "id": 1, "fullname": "Lindsay Fünke" }] }
+# GET "/users/1", response is { "users": { "id": 1, "fullname": "Lindsay Fünke" } }
 
 users = Users.all
 # GET "/users", response is { "users": [{ "id": 1, "fullname": "Lindsay Fünke" }, { "id": 2, "fullname": "Tobias Fünke" }] }

--- a/README.md
+++ b/README.md
@@ -592,12 +592,53 @@ class User
   include Her::Model
   parse_root_in_json true, format: :json_api
 end
+```
 
-user = Users.find(1)
+The JSON API spec recommends that individual resource representations be represented as a single "resource object". 
+
+```ruby
+user = User.find(1)
 # GET "/users/1", response is { "users": { "id": 1, "fullname": "Lindsay Fünke" } }
+```
 
-users = Users.all
+However, Her will also handle responses where individual resources are wrapped in an array, as shown below.
+
+```ruby
+user = User.find(1)
+# GET "/users/1", response is { "users": [{ "id": 1, "fullname": "Lindsay Fünke" }] }
+```
+
+Multiple resources should always be wrapped in an array.
+
+```ruby
+users = User.all
 # GET "/users", response is { "users": [{ "id": 1, "fullname": "Lindsay Fünke" }, { "id": 2, "fullname": "Tobias Fünke" }] }
+```
+
+For sending objects in JSON API format, you must decide whether to wrap individual resources in an array. For backwards compatibility, Her will wrap the object.
+
+```ruby
+class User
+  include Her::Model
+  parse_root_in_json true, format: :json_api
+  include_root_in_json :users
+end
+
+users = User.create(fullname: "Bob Loblaw")
+# POST "/users", request params are { "users": [{ "id": 1, "fullname": "Bob Loblaw" }] }
+```
+
+To disable wrapping of the individual resource, set the wrap_single_elements option for include_root_in_json to false as follows.
+
+```ruby
+class User
+  include Her::Model
+  parse_root_in_json true, format: :json_api
+  include_root_in_json :users, wrap_single_elements: false
+end
+
+users = User.create(fullname: "Bob Loblaw")
+# POST "/users", request params are { "users": { "id": 1, "fullname": "Bob Loblaw" } }
 ```
 
 ### Custom requests

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -42,11 +42,7 @@ module Her
           end
 
           if include_root_in_json?
-            if json_api_format?
-              { included_root_element => [filtered_attributes] }
-            else
-              { included_root_element => filtered_attributes }
-            end
+            { included_root_element => filtered_attributes }
           else
             filtered_attributes
           end

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -42,7 +42,11 @@ module Her
           end
 
           if include_root_in_json?
-            { included_root_element => filtered_attributes }
+            if json_api_format? && wrap_single_elements?
+              { included_root_element => [filtered_attributes] }
+            else
+              { included_root_element => filtered_attributes }
+            end
           else
             filtered_attributes
           end
@@ -75,6 +79,7 @@ module Her
         def include_root_in_json(value, options = {})
           @_her_include_root_in_json = value
           @_her_include_root_in_json_format = options[:format]
+          @_her_wrap_single_elements = options.fetch(:wrap_single_elements) { true }
         end
 
         # Return or change the value of `parse_root_in_json`
@@ -205,6 +210,11 @@ module Her
         # @private
         def parse_root_in_json?
           @_her_parse_root_in_json || (superclass.respond_to?(:parse_root_in_json?) && superclass.parse_root_in_json?)
+        end
+
+        # @private
+        def wrap_single_elements?
+          @_her_wrap_single_elements || (superclass.respond_to?(:wrap_single_elements?) && superclass.wrap_single_elements?)
         end
       end
     end

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -21,7 +21,7 @@ module Her
         def parse(data)
           if parse_root_in_json? && root_element_included?(data)
             if json_api_format?
-              data.fetch(parsed_root_element).first
+              Array.wrap(data.fetch(parsed_root_element)).first
             else
               data.fetch(parsed_root_element) { data }
             end

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -239,10 +239,23 @@ describe Her::Model::Parse do
         builder.adapter :test do |stub|
           stub.get("/users") { |env| [200, {},  { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
           stub.get("/users/admins") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
+
+          # json api
           stub.get("/users/1") { |env| [200, {}, { :users => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
           stub.post("/users") { |env| [200, {}, { :users => { :fullname => "Lindsay Fünke" } }.to_json] }
           stub.put("/users/1") { |env| [200, {}, { :users => { :id => 1, :fullname => "Tobias Fünke Jr." } }.to_json] }
+
+          # make sure json api changes maintain backwards compatibility
+          stub.get("/managers/1") { |env| [200, {}, { :managers => [{ :id => 1, :fullname => "jimmy mcnulty" }] }.to_json] }
+          stub.post("/managers") { |env|  [200, {}, { :managers => [{ :fullname => "bob loblaw" }] }.to_json] }
+          stub.put("/managers/1") { |env| [200, {}, { :managers => [{ :id => 1, :fullname => "bunk moreland" }] }.to_json] }
         end
+      end
+
+      spawn_model("Foo::Manager") do
+        parse_root_in_json true, :format => :json_api
+        include_root_in_json true
+        custom_get :admins
       end
 
       spawn_model("Foo::User") do
@@ -250,6 +263,11 @@ describe Her::Model::Parse do
         include_root_in_json true
         custom_get :admins
       end
+    end
+
+    it "parses the data from the JSON root element after .create even if wrapped in array" do
+      @new_manager = Foo::Manager.create(:fullname => "bob loblaw")
+      @new_manager.fullname.should == "bob loblaw"
     end
 
     it "parse the data from the JSON root element after .create" do
@@ -267,9 +285,20 @@ describe Her::Model::Parse do
       @users.first.fullname.should == "Lindsay Fünke"
     end
 
-    it "parse the data from the JSON root element after .find" do
+    it "parses the data from the JSON root element after .find even if wrapped in an array" do
+      @manager = Foo::Manager.find(1)
+      @manager.fullname.should == "jimmy mcnulty"
+    end
+
+    it "parses the data from the JSON root element after .find" do
       @user = Foo::User.find(1)
       @user.fullname.should == "Lindsay Fünke"
+    end
+
+    it "parses the data from the JSON root element after .save even if wrapped in array" do
+      @manager = Foo::Manager.find(1)
+      @manager.save
+      @manager.fullname.should == "bunk moreland"
     end
 
     it "parse the data from the JSON root element after .save" do
@@ -279,11 +308,18 @@ describe Her::Model::Parse do
       @user.fullname.should == "Tobias Fünke Jr."
     end
 
+    it "parse the data from the JSON root element after new/save if wrapped in array" do
+      @manager = Foo::User.new
+      @manager.fullname = "Lindsay Fünke (before save)"
+      @manager.save
+      @manager.fullname.should == "Lindsay Fünke"
+    end
+
     it "parse the data from the JSON root element after new/save" do
-      @user = Foo::User.new
-      @user.fullname = "Lindsay Fünke (before save)"
-      @user.save
-      @user.fullname.should == "Lindsay Fünke"
+      @manager = Foo::Manager.new
+      @manager.fullname = "bob loblaw (before create)"
+      @manager.save
+      @manager.fullname.should == "bob loblaw"
     end
   end
 

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -310,7 +310,7 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        @new_user.to_params.should == { :users => [{ :fullname => "Tobias Fünke" }] }
+        @new_user.to_params.should == { :users => { :fullname => "Tobias Fünke" } }
       end
 
       it "wraps params in the element name in `.where`" do

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -239,9 +239,9 @@ describe Her::Model::Parse do
         builder.adapter :test do |stub|
           stub.get("/users") { |env| [200, {},  { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
           stub.get("/users/admins") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :users => [{ :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Tobias Fünke Jr." }] }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { :users => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
+          stub.post("/users") { |env| [200, {}, { :users => { :fullname => "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { :users => { :id => 1, :fullname => "Tobias Fünke Jr." } }.to_json] }
         end
       end
 
@@ -295,7 +295,7 @@ describe Her::Model::Parse do
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.post("/users") { |env| [200, {}, { :users => [{ :id => 1, :fullname => params(env)[:users][:fullname] }] }.to_json] }
+        stub.post("/users") { |env| [200, {}, { :users => { :id => 1, :fullname => params(env)[:users][:fullname] } }.to_json] }
       end
     end
 

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -346,6 +346,26 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke")
+        @new_user.to_params.should == { :users => [{ :fullname => "Tobias Fünke" }] }
+      end
+
+      it "wraps params in the element name in `.where`" do
+        @new_user = Foo::User.where(:fullname => "Tobias Fünke").build
+        @new_user.fullname.should == "Tobias Fünke"
+      end
+    end
+
+    context "to true and wraps_single_elements set to false" do
+      before do
+        spawn_model "Foo::User" do
+          include_root_in_json true, wrap_single_elements: false
+          parse_root_in_json true, format: :json_api
+          custom_post :admins
+        end
+      end
+
+      it "wraps params in the element name in `to_params`" do
+        @new_user = Foo::User.new(:fullname => "Tobias Fünke")
         @new_user.to_params.should == { :users => { :fullname => "Tobias Fünke" } }
       end
 


### PR DESCRIPTION
...eturn individual resources as one element arrays

Per json api spec, an *"individual resource SHOULD be represented as a single 'resource object'"*, not a one-element array. From their documentation

```
{
  "posts": {
    "id": "1",
    // ... attributes of this post
  }
}
```

this change maintains backwards compatibility, but updates specs and documentation to espouse the recommended specification.