### PR TITLE
Handle has one and accepts nil value for it

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -39,7 +39,6 @@ module Her
 
         run_callbacks callback do
           run_callbacks :save do
-            params = to_params
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
               @metadata = parsed_data[:metadata]

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -63,8 +63,7 @@ module Her
         def has_one_embedded_params(attributes)
           present_has_ones = associations[:has_one].select { |a| attributes.include?(a[:data_key]) }
           present_has_ones.compact.each_with_object({}) do |association, hash|
-            params = attributes[association[:data_key]].to_params
-            next if params.empty?
+            params = attributes[association[:data_key]].try(:to_params)
             klass = her_nearby_class(association[:class_name])
             hash[association[:data_key]] = klass.include_root_in_json? ? params[klass.root_element] : params
           end

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -33,7 +33,7 @@ module Her
         # @private
         def to_params(attributes, changes={})
           filtered_attributes = attributes.dup.symbolize_keys
-          filtered_attributes.merge!(embeded_params(attributes))
+          filtered_attributes.merge!(embedded_params(attributes))
           if her_api.options[:send_only_modified_attributes]
             filtered_attributes = changes.symbolize_keys.keys.inject({}) do |hash, attribute|
               hash[attribute] = filtered_attributes[attribute]
@@ -54,18 +54,34 @@ module Her
 
 
         # @private
-        # TODO: Handle has_one
-        def embeded_params(attributes)
-          associations[:has_many].select { |a| attributes.include?(a[:data_key])}.compact.inject({}) do |hash, association|
+        def embedded_params(attributes)
+          has_many_params = has_many_embedded_params(attributes)
+          has_one_params  = has_one_embedded_params(attributes)
+          has_many_params.merge(has_one_params)
+        end
+
+        def has_one_embedded_params(attributes)
+          present_has_ones = associations[:has_one].select { |a| attributes.include?(a[:data_key]) }
+          present_has_ones.compact.each_with_object({}) do |association, hash|
+            params = attributes[association[:data_key]].to_params
+            next if params.empty?
+            klass = her_nearby_class(association[:class_name])
+            hash[association[:data_key]] = klass.include_root_in_json? ? params[klass.root_element] : params
+          end
+        end
+
+        def has_many_embedded_params(attributes)
+          present_has_many = associations[:has_many].select { |a| attributes.include?(a[:data_key]) }
+          present_has_many.compact.each_with_object({}) do |association, hash|
             params = attributes[association[:data_key]].map(&:to_params)
             next if params.empty?
-            if association[:class_name].constantize.include_root_in_json?
-              root = association[:class_name].constantize.root_element
+            klass = her_nearby_class(association[:class_name])
+            if klass.include_root_in_json?
+              root = klass.root_element
               hash[association[:data_key]] = params.map { |n| n[root] }
             else
               hash[association[:data_key]] = params
             end
-            hash
           end
         end
 

--- a/lib/her/version.rb
+++ b/lib/her/version.rb
@@ -1,3 +1,3 @@
 module Her
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -245,6 +245,12 @@ describe Her::Model::Associations do
       params[:comments].length.should eq(2)
     end
 
+    it 'includes has_one relationships in params by default' do
+      params = @user_with_included_data.to_params
+      params[:role].should be_kind_of(Hash)
+      params[:role][:body].should eq("Admin")
+    end
+
     [:create, :save_existing, :destroy].each do |type|
       context "after #{type}" do
         let(:subject) { self.send("user_with_included_data_after_#{type}")}

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -251,6 +251,12 @@ describe Her::Model::Associations do
       params[:role][:body].should eq("Admin")
     end
 
+    it 'accepts nil values for has_one association' do
+      @user_with_included_data.role = nil
+      params = @user_with_included_data.to_params
+      params[:role].should be_nil
+    end
+
     [:create, :save_existing, :destroy].each do |type|
       context "after #{type}" do
         let(:subject) { self.send("user_with_included_data_after_#{type}")}
@@ -313,7 +319,7 @@ describe Her::Model::Associations do
       @user_without_included_data.company.name.should == "Bluth Company"
     end
 
-    it "does not require foreugn key to have nested object" do
+    it "does not require foreign key to have nested object" do
       @user_with_included_data_but_no_fk.company.name.should == "Bluth Company Inc."
     end
   end


### PR DESCRIPTION
Now has_one associations will be taken into account when calling to_params in the parent model. 
That allow us to save a parent model containing has_one associations.
For example:

    class Person
      include Her::Model
      has_one :nick_name
      attributes :name
    end

    class NickName
      include Her::Model
      attributes :origin, :author, :created_at
    end

    p = Person.first
    p.assign_attributes(name: 'José', 
      nick_name_attributes: {origin: 'high_school', author: 'Big Guy', created_at: 18.years.ago})
    p.save

Besides that nil value will be accepted:

    p = Person.first
    p.nick_name = nil
    p.save