### PR TITLE
Double quotes required for interpolation.

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -192,7 +192,7 @@ module Her
             unless instance_methods.include?(:"#{attribute}=")
               define_method("#{attribute}=") do |value|
                 @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")
-                self.send(:"#{attribute}_will_change!") if @attributes[:'#{attribute}'] != value
+                self.send(:"#{attribute}_will_change!") if @attributes[:"#{attribute}"] != value
                 @attributes[:"#{attribute}"] = value
               end
             end

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -41,6 +41,11 @@ describe "Her::Model and ActiveModel::Dirty" do
           user.should_not be_changed
         end
 
+        it "tracks only changed dirty attributes" do
+          user.fullname = user.fullname
+          user.fullname_changed?.should be_falsey
+        end
+
         it "tracks previous changes" do
           user.fullname = "Tobias Fünke"
           user.save


### PR DESCRIPTION
https://github.com/remiprev/her/commit/5020082333c7faa6362060da85b6a3a91e6d6db2#diff-7280373369c4cbefb4c1e7c1df8b8a36R142 Introduced a bug which affects the ActiveModel::Dirty implentation. Double quotes should be used for interpolation!

This bug causes any attribute modification to be tracked as a change, even when the "new" value is the same as the existing value. 