### PR TITLE
fix: make response parsing comply with JSON api for individual objects

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -172,7 +172,8 @@ module Her
         # @private
         def new_from_parsed_data(parsed_data)
           parsed_data = parsed_data.with_indifferent_access
-          new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
+          parsed = parse(parsed_data[:data])
+          new(parsed.merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
         end
 
         # Define the attributes that will be used to track dirty attributes and validations

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -21,7 +21,8 @@ module Her
         def parse(data)
           if parse_root_in_json? && root_element_included?(data)
             if json_api_format?
-              data.fetch(parsed_root_element).first
+
+              parse_json_api_format(data, parsed_root_element)
             else
               data.fetch(parsed_root_element) { data }
             end
@@ -49,6 +50,16 @@ module Her
             end
           else
             filtered_attributes
+          end
+        end
+
+        # @private
+        def parse_json_api_format(data, root_element)
+          element  = data.fetch(root_element)
+          if element.is_a?(Array)
+            element.first
+          else
+            element
           end
         end
 


### PR DESCRIPTION
In [this](http://jsonapi.org/format/#document-structure-individual-resource-representations) section of the JSON api spec, we see that it is possible for a JSON api spec compliant service to return a response in the form of an 'individual resource' object.
Example:
Both the following are valid
``` JSON
 {"users" : [{"id" : 1}]}
```
``` JSON
 {"users" : {"id" : 1}}
```

This fix makes it handle the "collection object" case properly. 
This behavior was mentioned in issue #114