### PR TITLE
avoid blank hash in embeded parameter

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -57,13 +57,17 @@ module Her
         # TODO: Handle has_one
         def embeded_params(attributes)
           associations[:has_many].select { |a| attributes.include?(a[:data_key])}.compact.inject({}) do |hash, association|
+            # avoid hash is nil
+            hash ||= {}
             params = attributes[association[:data_key]].map(&:to_params)
-            next if params.empty?
-            if association[:class_name].constantize.include_root_in_json?
-              root = association[:class_name].constantize.root_element
-              hash[association[:data_key]] = params.map { |n| n[root] }
-            else
-              hash[association[:data_key]] = params
+            # avoid nil in inject when params.empty?
+            if params.present?
+              if association[:class_name].constantize.include_root_in_json?
+                root = association[:class_name].constantize.root_element
+                hash[association[:data_key]] = params.map { |n| n[root] }
+              else
+                hash[association[:data_key]] = params
+              end
             end
             hash
           end


### PR DESCRIPTION
Hi Guys
just improve the generate embedded attributes(has_many relation).
if the has_many value is blank, will make errors in `embeded_params`, such as `TypeError: no implicit conversion of nil into Hash`, `NoMethodError: undefined method `[]=' for nil:NilClass`

so I have add method to make default in inject, set blank hash.
