### PR TITLE
Return result from `save` when using `create`

### DIFF
--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -122,8 +122,6 @@ module Her
         attributes ||= {}
         resource = @parent.new(@params.merge(attributes))
         resource.save
-
-        resource
       end
 
       # Fetch a resource and create it if it's not found


### PR DESCRIPTION
`create` and `save` should behave the same (`create` being a shortcut for instantiation + saving). This is useful because `save` can sometimes return false.