### PR TITLE
Map to_s rather than to_s array

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -19,7 +19,7 @@ module Her
         # @param [Hash] data
         # @private
         def parse(data)
-          if parse_root_in_json? && root_element_included?(data)
+          if parsed_root_element && root_element_included?(data)
             if json_api_format?
               data.fetch(parsed_root_element).first
             else
@@ -139,7 +139,7 @@ module Her
 
         # @private
         def root_element_included?(data)
-          data.keys.to_s.include? @_her_root_element.to_s
+          data.keys.map(&:to_s).include? @_her_root_element.to_s
         end
 
         # @private


### PR DESCRIPTION
As written currently, we are calling to_s on an array of data's keys then checking whether the @_her_root_element is part of the string. I'm betting that the intention is to call to_s on the individual key and then check whether the root element is included in the stringified array of keys.

There are some incidental side effects 
- if the root element is nil, root_element_included always returns true. 
- if the root element is 'foo' and there is an key in the data hash 'foobar', root_element_included? will return true.
