### PR TITLE
Update association_proxy.rb - singleton class can't be dumped error while trying to her model obejct in Rails.cache (file_store))

### DIFF
--- a/lib/her/model/associations/association_proxy.rb
+++ b/lib/her/model/associations/association_proxy.rb
@@ -33,8 +33,7 @@ module Her
           end
 
           # create a proxy to the fetched object's method
-          metaclass = (class << self; self; end)
-          metaclass.install_proxy_methods 'association.fetch', name
+          AssociationProxy.install_proxy_methods 'association.fetch', name
 
           # resend message to fetched object
           __send__(name, *args, &block)

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -22,6 +22,10 @@ describe Her::Model do
     it { should have_key(:name) }
     it { should have_key(:comments) }
   end
+  
+  it 'should be serialized without an error' do 
+    expect { Marshal.dump(subject.comments) }.not_to raise_error 
+  end 
 
   describe :[] do
     it { should_not have_key(:unknown_method_for_a_user) }


### PR DESCRIPTION
The metaclass defined here is causing the problem when I try to store her::Model object in Rails.cache with file_store. See the example below. Because if this I am not able to use latest her version in my project. Rails cache works fine with her version 0.6.8 after that it gives following error. 

```
[2] first »  metaclass = (class << self; self; end) 
=> #<Class:#<Object:0x000000017ce3f8>> < Object
[3] first »  Marshal.dump(metaclass)
TypeError: singleton class can't be dumped
from (pry):3:in `dump'
```