### PR TITLE
Update faraday link in api documentation

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -34,7 +34,7 @@ module Her
     #
     # @param [Hash] opts the Faraday options
     # @option opts [String] :url The main HTTP API root (eg. `https://api.example.com`)
-    # @option opts [String] :ssl A hash containing [SSL options](https://github.com/technoweenie/faraday/wiki/Setting-up-SSL-certificates)
+    # @option opts [String] :ssl A hash containing [SSL options](https://github.com/lostisland/faraday/wiki/Setting-up-SSL-certificates)
     #
     # @return Faraday::Connection
     #


### PR DESCRIPTION
Fix for broken link in documentation. Was also changed in: https://github.com/remiprev/her/commit/1fe68799f50cbfb057979b27984fb74ab2af0e9f