### PR TITLE
Typo in documentation

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -84,8 +84,6 @@ module Her
     # Define a custom parsing procedure. The procedure is passed the response object and is
     # expected to return a hash with three keys: a main data Hash, an errors Hash
     # and a metadata Hash.
-    #
-    # @private
     def request(opts={})
       method = opts.delete(:_method)
       path = opts.delete(:_path)


### PR DESCRIPTION
Method `request` isn't private.