### PR TITLE
Prevent syntax errors when `name` is a Symbol for a setter.

### DIFF
--- a/lib/her/model/associations/association_proxy.rb
+++ b/lib/her/model/associations/association_proxy.rb
@@ -8,7 +8,7 @@ module Her
           names.each do |name|
             module_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{name}(*args, &block)
-                #{target_name}.#{name}(*args, &block)
+                #{target_name}.public_send("#{name}", *args, &block)
               end
             RUBY
           end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -315,9 +315,7 @@ describe Her::Model::Associations do
   context "object returned by the association method" do
     before do
       spawn_model "Foo::Role" do
-        def present?
-          "of_course"
-        end
+        attr_accessor :name
       end
       spawn_model "Foo::User" do
         has_one :role
@@ -350,7 +348,8 @@ describe Her::Model::Associations do
     end
 
     it "calls missing methods on associated value" do
-      subject.present?.should == "of_course"
+      subject.name = "some name"
+      subject.name.should == "some name"
     end
 
     it "can use association methods like where" do


### PR DESCRIPTION
I've experienced an issue when trying to perform an assignment on an associated record. It complained about a syntax error on the modified line (specifically the `&` character). This change seems to solve that issue.