### PR TITLE
use a set rather than array to test existance of instance methods

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -186,10 +186,12 @@ module Her
         def attributes(*attributes)
           define_attribute_methods attributes
 
+          instance_methods_set = Set.new instance_methods
+
           attributes.each do |attribute|
             attribute = attribute.to_sym
 
-            unless instance_methods.include?(:"#{attribute}=")
+            unless instance_methods_set.include?(:"#{attribute}=")
               define_method("#{attribute}=") do |value|
                 @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")
                 self.send(:"#{attribute}_will_change!") if @attributes[:"#{attribute}"] != value
@@ -197,7 +199,7 @@ module Her
               end
             end
 
-            unless instance_methods.include?(:"#{attribute}?")
+            unless instance_methods_set.include?(:"#{attribute}?")
               define_method("#{attribute}?") do
                 @attributes.include?(:"#{attribute}") && @attributes[:"#{attribute}"].present?
               end


### PR DESCRIPTION
Her::Model::Attributes#attributes searches an array in a loop which causes a lot of performance overhead in large object graphs. 

Using a set rather than an array for lookup should significantly improve performance. 