### PR TITLE
Use method_defined? instead of instance_methods lookup

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -189,7 +189,7 @@ module Her
           attributes.each do |attribute|
             attribute = attribute.to_sym
 
-            unless instance_methods.include?(:"#{attribute}=")
+            unless method_defined?(:"#{attribute}=")
               define_method("#{attribute}=") do |value|
                 @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")
                 self.send(:"#{attribute}_will_change!") if @attributes[:'#{attribute}'] != value
@@ -197,7 +197,7 @@ module Her
               end
             end
 
-            unless instance_methods.include?(:"#{attribute}?")
+            unless method_defined?(:"#{attribute}?")
               define_method("#{attribute}?") do
                 @attributes.include?(:"#{attribute}") && @attributes[:"#{attribute}"].present?
               end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -187,8 +187,6 @@ module Her
           define_attribute_methods attributes
 
           attributes.each do |attribute|
-            attribute = attribute.to_sym
-
             unless method_defined?(:"#{attribute}=")
               define_method("#{attribute}=") do |value|
                 @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -265,4 +265,39 @@ describe Her::Model::Attributes do
       end
     end
   end
+
+  context "attributes class method" do
+    before do
+      spawn_model 'Foo::User' do
+        attributes :fullname, :document
+      end
+    end
+
+    context "instance" do
+      subject { Foo::User.new }
+
+      it { should respond_to(:fullname) }
+      it { should respond_to(:fullname=) }
+      it { should respond_to(:fullname?) }
+    end
+
+    it "defines setter that affects @attributes" do
+      user = Foo::User.new
+      user.fullname = 'Tobias Fünke'
+      user.attributes[:fullname].should eq('Tobias Fünke')
+    end
+
+    it "defines getter that reads @attributes" do
+      user = Foo::User.new
+      user.assign_attributes(fullname: 'Tobias Fünke')
+      user.fullname.should eq('Tobias Fünke')
+    end
+
+    it "defines predicate that reads @attributes" do
+      user = Foo::User.new
+      user.fullname?.should be_falsey
+      user.assign_attributes(fullname: 'Tobias Fünke')
+      user.fullname?.should be_truthy
+    end
+  end
 end


### PR DESCRIPTION
This one is related to #336 and #307 and solves problem more efficient and simple (no memoization).

There is no need to call `instance_methods` at all because Ruby already has `method_defined?` that internally uses hash lookup (`st_lookup` from `st.c`). After all, it doesn't create new array/set objects that is good too.