### PR TITLE
:attributes class method misbehavior

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -67,6 +67,9 @@ module Her
       # Configure ActiveModel callbacks
       extend ActiveModel::Callbacks
       define_model_callbacks :create, :update, :save, :find, :destroy, :initialize
+
+      # Define matchers for attr? and attr= methods
+      define_attribute_method_matchers
     end
   end
 end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -184,20 +184,22 @@ module Her
         #     attributes :name, :email
         #   end
         def attributes(*attributes)
-          define_attribute_methods attributes
-
           attributes.each do |attribute|
-            unless method_defined?(:"#{attribute}=")
-              define_method("#{attribute}=") do |value|
-                @attributes[:"#{attribute}"] = nil unless @attributes.include?(:"#{attribute}")
-                self.send(:"#{attribute}_will_change!") if @attributes[:"#{attribute}"] != value
-                @attributes[:"#{attribute}"] = value
-              end
-            end
+            define_attribute_method attribute
 
-            unless method_defined?(:"#{attribute}?")
-              define_method("#{attribute}?") do
-                @attributes.include?(:"#{attribute}") && @attributes[:"#{attribute}"].present?
+            generated_attribute_methods.module_eval do
+              unless method_defined?(:"#{attribute}=")
+                define_method("#{attribute}=") do |value|
+                  @attributes[attribute] = nil unless @attributes.include?(attribute)
+                  self.send(:"#{attribute}_will_change!") if @attributes[attribute] != value
+                  @attributes[attribute] = value
+                end
+              end
+
+              unless method_defined?(:"#{attribute}?")
+                define_method("#{attribute}?") do
+                  @attributes.include?(attribute) && @attributes[attribute].present?
+                end
               end
             end
           end

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -99,11 +99,11 @@ describe Her::JsonApi::Model do
 
     end
 
-    spawn_model("Foo::User", Her::JsonApi::Model)
+    spawn_model("Foo::User", type: Her::JsonApi::Model)
   end
 
   it 'allows configuration of type' do
-    spawn_model("Foo::Bar", Her::JsonApi::Model) do
+    spawn_model("Foo::Bar", type: Her::JsonApi::Model) do
       type :foobars
     end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -321,11 +321,11 @@ describe Her::Model::Attributes do
       end
 
       it "overrides setter method" do
-        Foo::User.instance_methods(false).should include(:fullname=)
+        Foo::User.generated_attribute_methods.instance_methods.should include(:fullname=)
       end
 
       it "overrides predicate method" do
-        Foo::User.instance_methods(false).should include(:fullname?)
+        Foo::User.generated_attribute_methods.instance_methods.should include(:fullname?)
       end
 
       it "defines setter that affects @attributes" do

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -347,5 +347,27 @@ describe Her::Model::Attributes do
         user.fullname?.should be_truthy
       end
     end
+
+    if ActiveModel::VERSION::MAJOR < 4
+      it "creates a new mutex" do
+        expect(Mutex).to receive(:new).once.and_call_original
+        spawn_model 'Foo::User' do
+          attributes :fullname
+        end
+        Foo::User.attribute_methods_mutex.should_not eq(Foo::User.generated_attribute_methods)
+      end
+    else
+      it "uses ActiveModel's mutex" do
+        Foo::User.attribute_methods_mutex.should eq(Foo::User.generated_attribute_methods)
+      end
+    end
+
+    it "uses a mutex" do
+      spawn_model 'Foo::User'
+      expect(Foo::User.attribute_methods_mutex).to receive(:synchronize).once.and_call_original
+      Foo::User.class_eval do
+        attributes :fullname, :documents
+      end
+    end
   end
 end

--- a/spec/support/macros/model_macros.rb
+++ b/spec/support/macros/model_macros.rb
@@ -3,13 +3,20 @@ module Her
     module Macros
       module ModelMacros
         # Create a class and automatically inject Her::Model into it
-        def spawn_model(klass, model_type=Her::Model, &block)
+        def spawn_model(klass, options={}, &block)
+          super_class = options[:super_class]
+          model_type = options[:type] || Her::Model
+          new_class = if super_class
+                        Class.new(super_class)
+                      else
+                        Class.new
+                      end
           if klass =~ /::/
             base, submodel = klass.split(/::/).map{ |s| s.to_sym }
             Object.const_set(base, Module.new) unless Object.const_defined?(base)
             Object.const_get(base).module_eval do
               remove_const submodel if constants.map(&:to_sym).include?(submodel)
-              submodel = const_set(submodel, Class.new)
+              submodel = const_set(submodel, new_class)
               submodel.send(:include, model_type)
               submodel.class_eval(&block) if block_given?
             end


### PR DESCRIPTION
In #337 a following case was [discussed](https://github.com/remiprev/her/pull/337#issuecomment-99238263):

```ruby
class A
  attr_accessor :foo
end

class B < A
  include Her::Model

  attributes :foo
end
```

One would expect that `:foo`, `:foo=` methods would be overriden but current implementation behaves not as expected. To be precise, `:foo` will be overriden but `:foo=` will not. Why? Because Her defines `:foo` and `:foo=` differently. Reader method `:foo` is defined using `define_attribute_method` from ActiveModel but `:foo=` is defined manually (but only if a method doesn't exist already). ActiveModel's `define_attribute_method` checks a method to exist too but it's doing it smarter. It doesn't call `method_defined?` for a whole class — it checks `generated_attribute_methods` which is a dynamically included module:

```ruby
def generated_attribute_methods #:nodoc:
  @generated_attribute_methods ||= Module.new {
    extend Mutex_m
  }.tap { |mod| include mod }
end

# ...

def instance_method_already_implemented?(method_name) #:nodoc:
  generated_attribute_methods.method_defined?(method_name)
end
```

So, ActiveModel is behaving smarter — it checks method for extistence but *only among the methods defined by itself*. ActiveModel has this behavior in 3.x and 4.x and we definitely should make Her to comply it. This issue is definitely a bug and we cannot wait for 1.0.0 to fix it.

This issue is test first so I could try to make it green.