### PR TITLE
Non-persisted records try to make HTTP calls for associations with nil foreign_key

### DIFF
--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -74,7 +74,7 @@ module Her
         def fetch
           foreign_key_value = @parent.attributes[@opts[:foreign_key].to_sym]
           data_key_value = @parent.attributes[@opts[:data_key].to_sym]
-          return @opts[:default].try(:dup) if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @params.empty?) || (@parent.persisted? && foreign_key_value.blank? && data_key_value.blank?)
+          return @opts[:default].try(:dup) if (@parent.attributes.include?(@name) && @parent.attributes[@name].nil? && @params.empty?) || (foreign_key_value.blank? && data_key_value.blank?)
 
           return @cached_result unless @params.any? || @cached_result.nil?
           return @parent.attributes[@name] unless @params.any? || @parent.attributes[@name].blank?

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -132,6 +132,7 @@ describe Her::Model::Associations do
 
       @user_with_included_data = Foo::User.find(1)
       @user_without_included_data = Foo::User.find(2)
+      @user_without_organization_and_not_persisted = Foo::User.new(organization_id: nil, name: "Katlin Fünke")
     end
 
     let(:user_with_included_data_after_create) { Foo::User.create }
@@ -208,6 +209,10 @@ describe Her::Model::Associations do
       @user_without_included_data.organization.should be_a(Foo::Organization)
       @user_without_included_data.organization.id.should == 2
       @user_without_included_data.organization.name.should == "Bluth Company"
+    end
+
+    it "returns nil if the foreign key is nil" do
+      @user_without_organization_and_not_persisted.organization.should be_nil
     end
 
     it "fetches belongs_to data even if it was included, only if called with parameters" do


### PR DESCRIPTION
If you create a new instance of a Her model and it has a belongs_to association which is nil it will try to fetch a record with ID=nil.

A short example:

```ruby
user = User.new(name: "Karlin", organization_id: nil)
user.organization # this throws an exception as it tries to fetch GET /organizations
```

The error from the test in the PR:

```
  1) Her::Model::Associations handling associations without details returns nil if the foreign key is nil
     Failure/Error: @user_without_organization_and_not_persisted.organization.should be_nil
     Faraday::Adapter::Test::Stubs::NotFound:
       no stubbed request for get /organizations
     # ./lib/her/api.rb:94:in `request'
     # ./lib/her/model/http.rb:56:in `request'
     # ./lib/her/model/http.rb:81:in `get_raw'
     # ./lib/her/model/http.rb:70:in `get'
     # ./lib/her/model/associations/belongs_to_association.rb:84:in `fetch'
     # ./lib/her/model/associations/association_proxy.rb:11:in `nil?'
     # ./lib/her/model/associations/association_proxy.rb:40:in `method_missing'
     # ./spec/model/associations_spec.rb:215:in `block (3 levels) in <top (required)>'
```

I think the correct behavior is to return nil no matter if the record is persisted or not.