### PR TITLE
Fix belongs_to associations for models with active_model_serializers format

### DIFF
--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -81,8 +81,10 @@ module Her
 
           path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
           path = build_association_path lambda { @klass.build_request_path(path_params) }
-          @klass.get(path, @params).tap do |result|
-            @cached_result = result if @params.blank?
+          @klass.get_raw(path, @params) do |parsed_data, response|
+            @klass.new_from_parsed_data(parsed_data).tap do |result|
+              @cached_result = result if @params.blank?
+            end
           end
         end
 

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -163,13 +163,20 @@ describe Her::Model::Parse do
           stub.post("/users") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
           stub.get("/users") { |env| [200, {}, { :users => [ { :id => 1, :fullname => "Lindsay Fünke" } ] }.to_json] }
           stub.get("/users/admins") { |env| [200, {}, { :users => [ { :id => 1, :fullname => "Lindsay Fünke" } ] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Tobias Fünke Jr." } }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke", :organization_id => 1 } }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Tobias Fünke Jr.", :organization_id => 1 } }.to_json] }
+          stub.get("/organizations/1") { |env| [200, {}, { :organization => { :id => 1, :name => "Github" } }.to_json] }
         end
 
         spawn_model("Foo::User") do
           parse_root_in_json true, :format => :active_model_serializers
           custom_get :admins
+
+          belongs_to :organization
+        end
+
+        spawn_model("Foo::Organization") do
+          parse_root_in_json true, :format => :active_model_serializers
         end
       end
 
@@ -198,6 +205,12 @@ describe Her::Model::Parse do
         @user.fullname = "Tobias Fünke"
         @user.save
         @user.fullname.should == "Tobias Fünke Jr."
+      end
+
+      it "parse the organization of the user" do
+        @user = Foo::User.find(1)
+
+        @user.organization.id.should == @user.organization_id
       end
     end
   end


### PR DESCRIPTION
If you have two associated models like this:

```ruby
class User
  parse_root_in_json true, :format => :active_model_serializers
  belongs_to :organization
end

class Organization
  parse_root_in_json true, :format => :active_model_serializers
end
```

And you try to do:

```ruby
user = User.find(1)
user.organization
```

you get an exception:

     NoMethodError:
       undefined method `keys' for nil:NilClass
     # ./lib/her/model/parse.rb:142:in `root_element_included?'
     # ./lib/her/model/parse.rb:22:in `parse'
     # ./lib/her/model/attributes.rb:175:in `new_from_parsed_data'
     # ./lib/her/model/associations/belongs_to_association.rb:85:in `block in fetch'
     # ./lib/her/model/associations/belongs_to_association.rb:84:in `tap'
     # ./lib/her/model/associations/belongs_to_association.rb:84:in `fetch'
     # ./lib/her/model/associations/association_proxy.rb:11:in `id'
     # ./lib/her/model/associations/association_proxy.rb:40:in `method_missing'

I added a failing test for this case and implemented a fix, where it is used `get_raw` instead of `get` when fetching a belongs_to association. This is needed because `get` assumes the data to be parsed is a collection if you have format: active_model_serializers, which is not correct. There is just one object in a belongs_to association.