### PR TITLE
Escape path variables

### DIFF
--- a/lib/her/model/paths.rb
+++ b/lib/her/model/paths.rb
@@ -106,8 +106,13 @@ module Her
 
           path.gsub(/:([\w_]+)/) do
             # Look for :key or :_key, otherwise raise an exception
-            value = $1.to_sym
-            parameters.delete(value) || parameters.delete(:"_#{value}") || raise(Her::Errors::PathError.new("Missing :_#{$1} parameter to build the request path. Path is `#{path}`. Parameters are `#{parameters.symbolize_keys.inspect}`.", $1))
+            key = $1.to_sym
+            value = parameters.delete(key) || parameters.delete(:"_#{key}")
+            if value
+              Faraday::Utils.escape value
+            else
+              raise(Her::Errors::PathError.new("Missing :_#{$1} parameter to build the request path. Path is `#{path}`. Parameters are `#{parameters.symbolize_keys.inspect}`.", $1))
+            end
           end
         end
 

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -8,66 +8,66 @@ describe Her::Model::Paths do
         spawn_model "Foo::User"
       end
 
-      describe "#build_request_path" do
+      describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::User.build_request_path(:id => "foo").should == "users/foo"
-          Foo::User.build_request_path(:id => nil).should == "users"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.new(:id => "foo").request_path.should == "users/foo"
+          Foo::User.new(:id => nil).request_path.should == "users"
+          Foo::User.new().request_path.should == "users"
         end
 
         it "builds paths with custom collection path" do
           Foo::User.collection_path "/utilisateurs"
-          Foo::User.build_request_path(:id => "foo").should == "/utilisateurs/foo"
-          Foo::User.build_request_path.should == "/utilisateurs"
+          Foo::User.new(:id => "foo").request_path.should == "/utilisateurs/foo"
+          Foo::User.new().request_path.should == "/utilisateurs"
         end
 
         it "builds paths with custom relative collection path" do
           Foo::User.collection_path "utilisateurs"
-          Foo::User.build_request_path(:id => "foo").should == "utilisateurs/foo"
-          Foo::User.build_request_path.should == "utilisateurs"
+          Foo::User.new(:id => "foo").request_path.should == "utilisateurs/foo"
+          Foo::User.new().request_path.should == "utilisateurs"
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
+          Foo::User.new(:id => "foo").request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
+          Foo::User.new().request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:organization_id => "acme").should == "/organizations/acme/utilisateurs"
+          Foo::User.new(:id => "foo", :organization_id => "acme").request_path.should == "/organizations/acme/utilisateurs/foo"
+          Foo::User.new(:organization_id => "acme").request_path.should == "/organizations/acme/utilisateurs"
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs"
+          Foo::User.new(:id => "foo").request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
+          Foo::User.new().request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs"
 
-          Foo::User.build_request_path(:id => "foo", :organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
-          Foo::User.build_request_path(:organization_id => "acme").should == "organizations/acme/utilisateurs"
+          Foo::User.new(:id => "foo", :organization_id => "acme").request_path.should == "organizations/acme/utilisateurs/foo"
+          Foo::User.new(:organization_id => "acme").request_path.should == "organizations/acme/utilisateurs"
         end
 
         it "builds paths with custom item path" do
           Foo::User.resource_path "/utilisateurs/:id"
-          Foo::User.build_request_path(:id => "foo").should == "/utilisateurs/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.new(:id => "foo").request_path.should == "/utilisateurs/foo"
+          Foo::User.new().request_path.should == "users"
         end
 
         it "builds paths with custom relative item path" do
           Foo::User.resource_path "utilisateurs/:id"
-          Foo::User.build_request_path(:id => "foo").should == "utilisateurs/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.new(:id => "foo").request_path.should == "utilisateurs/foo"
+          Foo::User.new().request_path.should == "users"
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
-          expect { Foo::User.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::User.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
 
         it "escapes the variable values" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
-          Foo::User.build_request_path(:_organization_id => 'лол', :id => "Привет").should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
-          Foo::User.build_request_path(:organization_id => 'лол', :id => "Привет").should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
+          Foo::User.new(:id => "Привет").request_path(:_organization_id => 'лол').should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
+          Foo::User.new(:organization_id => 'лол', :id => "Привет").request_path.should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
         end
       end
     end
@@ -77,56 +77,56 @@ describe Her::Model::Paths do
         spawn_model "Foo::AdminUser"
       end
 
-      describe "#build_request_path" do
+      describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::AdminUser.build_request_path(:id => "foo").should == "admin_users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.new(:id => "foo").request_path.should == "admin_users/foo"
+          Foo::AdminUser.new().request_path.should == "admin_users"
         end
 
         it "builds paths with custom collection path" do
           Foo::AdminUser.collection_path "/users"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "/users/foo"
-          Foo::AdminUser.build_request_path.should == "/users"
+          Foo::AdminUser.new(:id => "foo").request_path.should == "/users/foo"
+          Foo::AdminUser.new().request_path.should == "/users"
         end
 
         it "builds paths with custom relative collection path" do
           Foo::AdminUser.collection_path "users"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "users/foo"
-          Foo::AdminUser.build_request_path.should == "users"
+          Foo::AdminUser.new(:id => "foo").request_path.should == "users/foo"
+          Foo::AdminUser.new().request_path.should == "users"
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          Foo::AdminUser.build_request_path(:id => "foo", :_organization_id => "acme").should == "/organizations/acme/users/foo"
-          Foo::AdminUser.build_request_path(:_organization_id => "acme").should == "/organizations/acme/users"
+          Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme").should == "/organizations/acme/users/foo"
+          Foo::AdminUser.new().request_path(:_organization_id => "acme").should == "/organizations/acme/users"
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          Foo::AdminUser.build_request_path(:id => "foo", :_organization_id => "acme").should == "organizations/acme/users/foo"
-          Foo::AdminUser.build_request_path(:_organization_id => "acme").should == "organizations/acme/users"
+          Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme").should == "organizations/acme/users/foo"
+          Foo::AdminUser.new().request_path(:_organization_id => "acme").should == "organizations/acme/users"
         end
 
         it "builds paths with custom item path" do
           Foo::AdminUser.resource_path "/users/:id"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "/users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.new(:id => "foo").request_path.should == "/users/foo"
+          Foo::AdminUser.new().request_path.should == "admin_users"
         end
 
         it "builds paths with custom relative item path" do
           Foo::AdminUser.resource_path "users/:id"
-          Foo::AdminUser.build_request_path(:id => "foo").should == "users/foo"
-          Foo::AdminUser.build_request_path.should == "admin_users"
+          Foo::AdminUser.new(:id => "foo").request_path.should == "users/foo"
+          Foo::AdminUser.new().request_path.should == "admin_users"
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          expect { Foo::AdminUser.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
 
         it "raises exceptions when building a relative path without required custom variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          expect { Foo::AdminUser.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
       end
     end
@@ -158,10 +158,10 @@ describe Her::Model::Paths do
         spawn_model "Foo::User"
       end
 
-      describe "#build_request_path" do
+      describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::User.build_request_path(:id => "foo").should == "users/foo"
-          Foo::User.build_request_path.should == "users"
+          Foo::User.new(:id => "foo").request_path.should == "users/foo"
+          Foo::User.new.request_path.should == "users"
         end
       end
     end
@@ -179,15 +179,15 @@ describe Her::Model::Paths do
         end
       end
 
-      describe '#build_request_path' do
+      describe '#request_path' do
         it 'uses the correct primary key attribute' do
-          User.build_request_path(:UserId => 'foo').should == 'users/foo'
-          User.build_request_path(:id => 'foo').should == 'users'
+          User.new(:UserId => 'foo').request_path.should == 'users/foo'
+          User.new(:id => 'foo').request_path.should == 'users'
         end
 
         it 'replaces :id with the appropriate primary key' do
-          Customer.build_request_path(:customer_id => 'joe').should == 'customers/joe'
-          Customer.build_request_path(:id => 'joe').should == 'customers'
+          Customer.new(:customer_id => 'joe').request_path.should == 'customers/joe'
+          Customer.new(:id => 'joe').request_path.should == 'customers'
         end
       end
     end

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -63,6 +63,12 @@ describe Her::Model::Paths do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
           expect { Foo::User.build_request_path(:id => "foo") }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
+
+        it "escapes the variable values" do
+          Foo::User.collection_path "organizations/:organization_id/utilisateurs"
+          Foo::User.build_request_path(:_organization_id => 'лол', :id => "Привет").should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
+          Foo::User.build_request_path(:organization_id => 'лол', :id => "Привет").should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
+        end
       end
     end
 


### PR DESCRIPTION
When dealing with parameters in a query string (`?a=1&b=blabla`) Faraday escapes keys and values using `Faraday::Utils.escape` helper. But when parameters are passed in a path string (RESTful way) it doesn't happen so for example when `id` value is something non-ascii.
Since http path building is done on the Her side, it should be fixed here.