### PR TITLE
Feature/jsonapi compound documents

### DIFF
--- a/lib/her/middleware/json_api_parser.rb
+++ b/lib/her/middleware/json_api_parser.rb
@@ -1,7 +1,7 @@
 module Her
   module Middleware
-    # This middleware expects the resource/collection data to be contained in the `data`
-    # key of the JSON object
+    # This middleware requires the resource/collection
+    # data to be contained in the `data` key of the JSON object
     class JsonApiParser < ParseJSON
       # Parse the response body
       #
@@ -11,11 +11,34 @@ module Her
       def parse(body)
         json = parse_json(body)
 
+        included = json.fetch(:included, [])
+        primary_data = json.fetch(:data, {})
+        Array.wrap(primary_data).each do |resource|
+          resource_relationships = resource.delete(:relationships) { {} }
+          resource[:attributes].merge!(populate_relationships(resource_relationships, included.dup))
+        end
+
         {
-          :data => json[:data] || {},
+          :data => primary_data || {},
           :errors => json[:errors] || [],
           :metadata => json[:meta] || {},
         }
+      end
+
+      def populate_relationships(relationships, included)
+        return {} if included.empty?
+        {}.tap do |built|
+          relationships.each do |rel_name, linkage|
+            linkage_data = linkage.fetch(:data, {})
+            built_relationship = if linkage_data.is_a? Array
+              linkage_data.map { |l| included.detect { |i| i.values_at(:id, :type) == l.values_at(:id, :type) } }.compact
+            else
+              included.detect { |i| i.values_at(:id, :type) == linkage_data.values_at(:id, :type) }
+            end
+
+            built[rel_name] = built_relationship
+          end
+        end
       end
 
       # This method is triggered when the response has been received. It modifies
@@ -26,7 +49,11 @@ module Her
       def on_complete(env)
         env[:body] = case env[:status]
         when 204
-          parse('{}')
+          {
+            :data => {},
+            :errors => [],
+            :metadata => {},
+          }
         else
           parse(env[:body])
         end


### PR DESCRIPTION
all. i've added very basic support for compound documents. 

similar to the earlier commits initial support of JSON API, it moves the included documents into the same namespace as the attributes. however, since JSON API specifies that attributes and included objects occupy the same namespace, there shouldn't be issues with conflicts provided the response is JSON API-compliant.

we're losing some context here by taking this tact, but this allows us to retrieve multiple resources at once in a way that will be compatible with JSON API development efforts down the road. 

the next step will on this front will be to figure out how to generate associations based on the links that are returned rather than relying on a static object that specifies the path. 

feedback very much appreciated.