### PR TITLE
add reload for associations

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -65,6 +65,13 @@ module Her
           end
         end
 
+        # @private
+        def reset
+          @params = {}
+          @cached_result = nil
+          @parent.attributes.delete(@name)
+        end
+
         # Add query parameters to the HTTP request performed to fetch the data
         #
         # @example
@@ -95,6 +102,29 @@ module Her
           return nil if id.blank?
           path = build_association_path lambda { "#{@parent.request_path(@params)}#{@opts[:path]}/#{id}" }
           @klass.get_resource(path, @params)
+        end
+
+        # Refetches the association and puts the proxy back in its initial state, 
+        # which is unloaded. Cached associations are cleared.
+        #
+        # @example
+        #   class User
+        #     include Her::Model
+        #     has_many :comments
+        #   end
+        #
+        #   class Comment
+        #     include Her::Model
+        #   end
+        #
+        #   user = User.find(1)
+        #   user.comments = [#<Comment(comments/2) id=2 body="Hello!">]
+        #   user.comments.first.id = "Oops"
+        #   user.comments.reload # => [#<Comment(comments/2) id=2 body="Hello!">]
+        #   # Fetched again via GET "/users/1/comments"
+        def reload
+          reset
+          fetch
         end
 
       end

--- a/lib/her/model/associations/association_proxy.rb
+++ b/lib/her/model/associations/association_proxy.rb
@@ -15,7 +15,7 @@ module Her
         end
 
         install_proxy_methods :association,
-          :build, :create, :where, :find, :all, :assign_nested_attributes
+          :build, :create, :where, :find, :all, :assign_nested_attributes, :reload
 
         # @private
         def initialize(association)

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -182,6 +182,10 @@ describe Her::Model::Associations do
       @user_without_included_data.comments.first.object_id.should_not == @user_without_included_data.comments.where(:foo_id => 1).first.object_id
     end
 
+    it "fetches data again after being reloaded" do
+      expect { @user_without_included_data.comments.reload }.to change { @user_without_included_data.comments.first.object_id }
+    end
+
     it "maps an array of included data through has_one" do
       @user_with_included_data.role.should be_a(Foo::Role)
       @user_with_included_data.role.object_id.should == @user_with_included_data.role.object_id


### PR DESCRIPTION
similar to ActiveRecord [reload](http://apidock.com/rails/ActiveRecord/Associations/Association/reload), this will bust the cache and refetch an association.
