### PR TITLE
Enable customizable JSON serialization on Model and Relation

### DIFF
--- a/lib/her/model.rb
+++ b/lib/her/model.rb
@@ -7,6 +7,7 @@ require "her/model/orm"
 require "her/model/parse"
 require "her/model/associations"
 require "her/model/introspection"
+require "her/model/serialization"
 require "her/model/paths"
 require "her/model/nested_attributes"
 require "active_model"
@@ -33,6 +34,7 @@ module Her
     include Her::Model::HTTP
     include Her::Model::Parse
     include Her::Model::Introspection
+    include Her::Model::Serialization
     include Her::Model::Paths
     include Her::Model::Associations
     include Her::Model::NestedAttributes

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -38,6 +38,22 @@ module Her
       end
       alias all where
 
+      # Return a JSON serialized string representing the fetched collection of models
+      #
+      # @see Model::Serialization#to_json
+      #   for list of allowable options
+      def to_json(options = {})
+        as_json(options).to_json
+      end
+
+      # Map all of the fetched models as Hashes preparing for JSON serialization
+      #
+      # @see Model::Serialization#to_json
+      #   for list of allowable options
+      def as_json(options = {})
+        fetch.map { |model| model.as_json(options) }
+      end
+
       # Bubble all methods to the fetched collection
       #
       # @private

--- a/lib/her/model/serialization.rb
+++ b/lib/her/model/serialization.rb
@@ -1,0 +1,49 @@
+module Her
+  module Model
+    module Serialization
+      # Return JSON serialized string representing the model
+      #
+      # @params options [Hash] options to select the contents of the returned String,
+      #   note that the values in the options can be Strings or Symbols
+      # @option options :only [String|Array<String>] the name or a list of names
+      #   of attributes to include to the exclusion of all others
+      # @option options :execpt [String|Array<String>] the name or a list of
+      #   names of attributes to exclude from the returned String
+      # @option options :methods [String|Array<String>] the name or a list of
+      #   names of methods to include in addition to the attributes
+      #
+      # @example
+      #   class User
+      #     include Her::Model
+      #   end
+      #
+      #   @user = User.find(1)
+      #   p @user.to_json # => '{"id":1,"name":"Tobias Fünke"}'
+      #   p @user.to_json(only: "name") # => '{"name":"Tobias Fünke"}'
+      def to_json(options = {})
+        as_json(options).to_json
+      end
+
+      # Return a Hash representing the model, preparing for JSON serialization
+      #
+      # @see #to_json
+      #   for list of allowable options
+      def as_json(options = {})
+        options = options.symbolize_keys
+
+        if options.key?(:only)
+          hash = attributes.slice(*Array.wrap(options[:only]).map(&:to_s))
+        elsif options.key?(:except)
+          exclude_keys = Array.wrap(options[:except]).map(&:to_s)
+          hash = attributes.reject { |key, _value| exclude_keys.include?(key) }
+        else
+          hash = attributes.dup
+        end
+
+        Array.wrap(options[:methods]).each { |method| hash[method.to_s] = send(method) }
+
+        hash
+      end
+    end
+  end
+end

--- a/spec/model/serialization_spec.rb
+++ b/spec/model/serialization_spec.rb
@@ -1,0 +1,82 @@
+# encoding: utf-8
+require File.join(File.dirname(__FILE__), "../spec_helper.rb")
+
+describe Her::Model::Serialization do
+  context "serializing a resource" do
+    before do
+      Her::API.setup :url => "https://api.example.com" do |builder|
+        builder.use Her::Middleware::FirstLevelParseJSON
+        builder.use Faraday::Request::UrlEncoded
+        builder.adapter :test do |stub|
+          stub.post("/users")     { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
+          stub.get("/users/1")    { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
+          stub.put("/users/1")    { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
+          stub.delete("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
+          stub.get("/projects/1/comments") { |env| [200, {}, [{ :id => 1, :body => "Hello!" }].to_json] }
+        end
+      end
+
+      spawn_model "Foo::User" do
+        define_method :email do
+          # Return an email address using the Users first name
+          "#{name.split.first.downcase}@test.com"
+        end
+      end
+    end
+
+    describe :to_json do
+      it "returns a JSON string with all attributes" do
+        @user = Foo::User.find(1)
+        json_string = @user.to_json
+        json_string.should == '{"name":"Tobias Funke","id":1}'
+      end
+
+      it "forwards options to #as_json" do
+        @user = Foo::User.find(1)
+        json_string = @user.to_json(only: "name")
+        json_string.should == '{"name":"Tobias Funke"}'
+      end
+    end
+
+    describe :as_json do
+      it "returns a Hash with all attributes" do
+        @user = Foo::User.find(1)
+        hash = @user.as_json
+        hash.length.should == 2
+        hash.should have_key("id")
+        hash['id'].should == 1
+        hash.should have_key("name")
+        hash['name'].should == "Tobias Funke"
+      end
+
+      context "only" do
+        it "only includes the given attributes" do
+          @user = Foo::User.find(1)
+          hash = @user.as_json(only: "name")
+          hash.length.should == 1
+          hash.should have_key("name")
+          hash['name'].should == "Tobias Funke"
+        end
+      end
+
+      context "except" do
+        it "excludes the given attributes" do
+          @user = Foo::User.find(1)
+          hash = @user.as_json(except: "name")
+          hash.length.should == 1
+          hash.should have_key("id")
+          hash['id'].should == 1
+        end
+      end
+
+      context "methods" do
+        it "includes the value of the given methods" do
+          @user = Foo::User.find(1)
+          hash = @user.as_json(methods: "email")
+          hash.should have_key("email")
+          hash['email'].should == "tobias@test.com"
+        end
+      end
+    end
+  end
+end

--- a/spec/model/serialization_spec.rb
+++ b/spec/model/serialization_spec.rb
@@ -49,32 +49,44 @@ describe Her::Model::Serialization do
         hash['name'].should == "Tobias Funke"
       end
 
-      context "only" do
-        it "only includes the given attributes" do
-          @user = Foo::User.find(1)
-          hash = @user.as_json(only: "name")
-          hash.length.should == 1
-          hash.should have_key("name")
-          hash['name'].should == "Tobias Funke"
+      [:only, "only"].each do |key|
+        [:name, "name", [:name], ["name"]].each do |value|
+          context "#{key.inspect} => #{value.inspect}" do
+            it "only includes the given attributes" do
+              @user = Foo::User.find(1)
+              hash = @user.as_json(key => value)
+              hash.length.should == 1
+              hash.should have_key("name")
+              hash['name'].should == "Tobias Funke"
+            end
+          end
         end
       end
 
-      context "except" do
-        it "excludes the given attributes" do
-          @user = Foo::User.find(1)
-          hash = @user.as_json(except: "name")
-          hash.length.should == 1
-          hash.should have_key("id")
-          hash['id'].should == 1
+      [:except, "except"].each do |key|
+        [:name, "name", [:name], ["name"]].each do |value|
+          context "#{key.inspect} => #{value.inspect}" do
+            it "excludes the given attributes" do
+              @user = Foo::User.find(1)
+              hash = @user.as_json(key => value)
+              hash.length.should == 1
+              hash.should have_key("id")
+              hash['id'].should == 1
+            end
+          end
         end
       end
 
-      context "methods" do
-        it "includes the value of the given methods" do
-          @user = Foo::User.find(1)
-          hash = @user.as_json(methods: "email")
-          hash.should have_key("email")
-          hash['email'].should == "tobias@test.com"
+      [:methods, "methods"].each do |key|
+        [:email, "email", [:email], ["email"]].each do |value|
+          context "#{key.inspect} => #{value.inspect}" do
+            it "includes the value of the given methods" do
+              @user = Foo::User.find(1)
+              hash = @user.as_json(key => value)
+              hash.should have_key("email")
+              hash['email'].should == "tobias@test.com"
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
One use case I have for the Her gem is to retrieve resources from a remote app to be used in the Javascript client of the local app. This entails serializing the Her models into JSON to be returned by a controller in the local app.

This PR introduces `#to_json` and `#as_json` on both the `Model` and `Relation`. `#to_json` will return a nicely formatted JSON string that a Javascript (or other) client of the local app can easily consume.

The interface was explicitly modeled after <a href="http://api.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html">`ActiveModel::Serializers::JSON`</a> and accepts the `:only`, `:except`, and `:methods` options. Keep in mind, this is an incomplete copy of `ActiveModel` functionality, as it does not honor the `:root` or `:include` options. However, it satisfies my current needs and can be extended to accept those options in the future as other developers need them.

While `#to_json` is the primary interface for serializing models and collections, I chose to keep `#as_json` part of the public interface like `ActiveModel` does because it is useful when constructing arbitrary JSON strings, e.g. 

```ruby
response = { user: user.as_json(except: :auth_token), request_id: Request.uuid }
response.to_json
```

### Example usage
```ruby
class User
  include Her::Model

  def best_friend
    # complicated logic to calculate User's best friend
  end
end

user = User.find(1)
p user.to_json(except: [:auth_token])
# {"id":1,name:"Tobias Fünke"}
p user.to_json(methods: "best_friend")
# {"id":1,name:"Tobias Fünke","auth_token":"deadbeef","best_friend":"Lindsay Fünke"}

users = User.all
p users.to_json("only" => "id")
# [{"id":1},{"id":2}]
```