### PR TITLE
Change default behavior of comparison operator like Activerecord

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -141,7 +141,7 @@ module Her
       #
       # @private
       def ==(other)
-        other.is_a?(Her::Model) && id == other.id
+        other.is_a?(Her::Model) && self.class == other.class && id == other.id
       end
 
       # Delegate to the == method

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -141,7 +141,7 @@ module Her
       #
       # @private
       def ==(other)
-        other.is_a?(Her::Model) && @attributes == other.attributes
+        other.is_a?(Her::Model) && id == other.id
       end
 
       # Delegate to the == method

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -110,8 +110,8 @@ describe Her::Model::Attributes do
       user.should == Foo::User.new(:id => 1, :fullname => "Lindsay Fünke")
     end
 
-    it "returns true for a different resource with the same data" do
-      user.should == Foo::Admin.find(1)
+    it "returns false for a different resource with the same data" do
+      user.should_not == Foo::Admin.find(1)
     end
 
     it "returns false for the same class with different data" do


### PR DESCRIPTION
her's comparison operator returns false if one object is find from relational methods but Activerecord returns true in same situations.

```
class CustomerResource
  include Her::Model
  has_many :orders
end

class OrderResource
  include Her::Model
  belongs_to :customer
end

> OrderResource.find(1) == OrderResource.find(1)
true
> CustomerResource.orders.find(1) == OrderResource.find(1)
false

class Customer < ActiveRecord::Base
  has_many :orders
end

class Order < ActiveRecord::Base
  belongs_to :customer
end

> Order.find(1) == Order.find(1)
true
> Customer.orders.find(1) == Order.find(1)
true

```

Main cause of that object which includes Her::Model has relation attributes when find from relational resource.

```
Customer.orders.find(1).attributes[:customer_resource]
<CustomerResource(cusotomers/1) price="1000" created_at="2015-10-27T17:01:19.000+09:00" updated_at="2015-10-27T17:02:47.000+09:00" id=1>
```

I think it should be better if her's comparison method works same as Activerecord one.
https://github.com/rails/rails/blob/master/activerecord/lib/active_record/core.rb#L409-L414
