### PR TITLE
Add #update and #update! methods into the Her::Model::ORM module

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ end
 # Update a fetched resource
 user = User.find(1)
 user.fullname = "Lindsay Fünke" # OR user.assign_attributes(fullname: "Lindsay Fünke")
-user.save # returns false if it fails, errors in user.response_errors array
+user.save # returns false if it fails, errors in user.response_errors array # OR user.update(fullname: "Lindsay Fünke")
 # PUT "/users/1" with `fullname=Lindsay+Fünke`
 
 # Update a resource without fetching it

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -65,6 +65,27 @@ module Her
         end
         self
       end
+      
+      # Update a resource and return `false` if the response is not a successful one or
+      # if there are errors in the resource. Otherwise, return the newly updated resource
+      #
+      # @example Update a resource after fetching it
+      #   @user = User.find(1)
+      #   # Fetched via GET "/users/1"
+      #   @user.update(fullname: "Tobias Fünke")
+      #   # Called via PUT "/users/1"
+      def update(attributes)
+        assign_attributes(attributes)
+        save
+      end
+
+      # Similar to update(), except that ResourceInvalid is raised if the update fails
+      def update!(attributes)
+        if !self.update(attributes)
+          raise Her::Errors::ResourceInvalid, self
+        end
+        self
+      end
 
       # Destroy a resource
       #


### PR DESCRIPTION
I'd like to add #update and #update! methods into the Her::Model::ORM module because recently I'm replacing ActiveRecord model with a including Her::Model resource. my project uses ActiveRecord::Persistence#update method a lots.

e.g.

```
class User < ActiveRecord::Base
end

@user = User.find(1)
@user.update(fullname: "Lindsay Fünke")
```

 It would be very happy If her provides #update and #update! methods.
