### PR TITLE
JSON API destroy_existing bug

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -75,8 +75,9 @@ module Her
       #   # Called via DELETE "/users/1"
       def destroy(params = {})
         method = self.class.method_for(:destroy)
+        path = request_path(params)
         run_callbacks :destroy do
-          self.class.request(params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
+          self.class.request(params.merge(:_method => method, :_path => path)) do |parsed_data, response|
             assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
             @metadata = parsed_data[:metadata]
             @response_errors = parsed_data[:errors]
@@ -159,9 +160,9 @@ module Her
         #   User.destroy_existing(1)
         #   # Called via DELETE "/users/1"
         def destroy_existing(id, params={})
-          request(params.merge(:_method => method_for(:destroy), :_path => build_request_path(params.merge(primary_key => id)))) do |parsed_data, response|
-            new(parse(parsed_data[:data]).merge(:_destroyed => true))
-          end
+          resource = new(primary_key => id)
+          resource.destroy(params)
+          resource
         end
 
         # Return or change the HTTP method used to create or update records

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -5,8 +5,8 @@ describe Her::JsonApi::Model do
     Her::API.setup :url => "https://api.example.com" do |connection|
       connection.use Her::Middleware::JsonApiParser
       connection.adapter :test do |stub|
-        stub.get("/users/1") do |env| 
-          [ 
+        stub.get("/users/1") do |env|
+          [
             200,
             {},
             {
@@ -17,13 +17,13 @@ describe Her::JsonApi::Model do
                   name: "Roger Federer",
                 },
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
-        stub.get("/users") do |env| 
-          [ 
+        stub.get("/users") do |env|
+          [
             200,
             {},
             {
@@ -34,7 +34,7 @@ describe Her::JsonApi::Model do
                   attributes: {
                     name: "Roger Federer",
                   },
-                }, 
+                },
                 {
                   id:    2,
                   type: 'users',
@@ -44,7 +44,7 @@ describe Her::JsonApi::Model do
                 }
               ]
             }.to_json
-          ] 
+          ]
         end
 
         stub.post("/users", data: {
@@ -53,7 +53,7 @@ describe Her::JsonApi::Model do
             name: "Jeremy Lin",
           },
         }) do |env|
-          [ 
+          [
             201,
             {},
             {
@@ -64,9 +64,9 @@ describe Her::JsonApi::Model do
                   name: 'Jeremy Lin',
                 },
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
         stub.patch("/users/1", data: {
@@ -76,7 +76,7 @@ describe Her::JsonApi::Model do
             name: "Fed GOAT",
           },
         }) do |env|
-          [ 
+          [
             200,
             {},
             {
@@ -87,16 +87,15 @@ describe Her::JsonApi::Model do
                   name: 'Fed GOAT',
                 },
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
         stub.delete("/users/1") { |env|
-          [ 204, {}, {}, ] 
+          [ 204, {}, {}, ]
         }
       end
-
     end
 
     spawn_model("Foo::User", type: Her::JsonApi::Model)
@@ -154,6 +153,14 @@ describe Her::JsonApi::Model do
   it 'destroys a Foo::User' do
     user = Foo::User.find(1)
     expect(user.destroy).to be_destroyed
+  end
+
+  describe 'class methods' do
+    it 'destroy_existing on Foo::User' do
+      destroyed = nil
+      expect { destroyed = Foo::User.destroy_existing(1) }.not_to raise_error
+      expect(destroyed).to be_destroyed
+    end
   end
 
   context 'undefined methods' do


### PR DESCRIPTION
Class method `destroy_existing` didn't work with JSON API responses. It was expecting `:attributes` field but JSON API by default response with `204 No Content`  for `DELETE` method.

This patch consolidates class method `destroy_existing` with object method `destroy` to fix the issue and avoid future issues by reducing duplicated code.
