### PR TITLE
Fix get when used for has_one relationships with active model serializers

### DIFF
--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -68,10 +68,11 @@ module Her
               path = build_request_path_from_string_or_symbol(path, params)
               params = to_params(params) unless #{method.to_sym.inspect} == :get
               send(:'#{method}_raw', path, params) do |parsed_data, response|
-                if parsed_data[:data].is_a?(Array) || active_model_serializers_format? || json_api_format?
+
+                if parsed_data[:data].is_a?(Array) || json_api_format? || (active_model_serializers_format? && parsed_data[:data].has_key?(pluralized_parsed_root_element))
                   new_collection(parsed_data)
                 else
-                  new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
+                  new_from_parsed_data(parsed_data)
                 end
               end
             end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ RSpec.configure do |config|
     @spawned_models = []
   end
 
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true 
+
   config.after :each do
     @spawned_models.each do |model|
       Object.instance_eval { remove_const model } if Object.const_defined?(model)


### PR DESCRIPTION
new_collection was called on even singular resources when format: :active_model_serializers was configured.

Example in specs