### PR TITLE
Adds Faraday options "timeout" and "open_timeout" accessible in her config

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -6,7 +6,7 @@ module Her
     attr_reader :connection, :options
 
     # Constants
-    FARADAY_OPTIONS = [:request, :proxy, :ssl, :builder, :url, :parallel_manager, :params, :headers, :builder_class].freeze
+    FARADAY_OPTIONS = [:request, :proxy, :ssl, :builder, :url, :parallel_manager, :params, :headers, :builder_class, :timeout, :open_timeout].freeze
 
     # Setup a default API connection. Accepted arguments and options are the same as {API#setup}.
     def self.setup(opts={}, &block)


### PR DESCRIPTION
Contrary to the the comments in this issue: https://github.com/remiprev/her/issues/120, the options `timeout` and `open_timeout` are not being accepted by Her.

Github page for [Faraday](https://github.com/lostisland/faraday)
