### PR TITLE
Provide metadata and response_errors for destroyed resources

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -160,7 +160,10 @@ module Her
         #   # Called via DELETE "/users/1"
         def destroy_existing(id, params={})
           request(params.merge(:_method => method_for(:destroy), :_path => build_request_path(params.merge(primary_key => id)))) do |parsed_data, response|
-            new(parse(parsed_data[:data]).merge(:_destroyed => true))
+            data = parse(parsed_data[:data])
+            metadata = parsed_data[:metadata]
+            response_errors = parsed_data[:errors]
+            new(data.merge(:_destroyed => true, :metadata => metadata, :response_errors => response_errors))
           end
         end
 

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -74,7 +74,9 @@ describe Her::Model::ORM do
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
           stub.get("/users") { [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: %w(Oh My God) }.to_json] }
-          stub.post("/users") { [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: %w(Yes Sir) }.to_json] }
+          stub.get("/users") { |env| [200, {}, { :data => [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }], :metadata => { :total_pages => 10, :next_page => 2 }, :errors => ["Oh", "My", "God"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { :data => { :name => "George Michael Bluth" }, :metadata => { :foo => "bar" }, :errors => ["Yes", "Sir"] }.to_json] }
+          stub.delete("/users/1") { |env| [200, {}, { :data => { :id => 1 }, :metadata => { :foo => "bar" }, :errors => ["Yes", "Sir"] }.to_json] }
         end
       end
 
@@ -101,6 +103,16 @@ describe Her::Model::ORM do
     it "handles error data on a resource" do
       @user = User.create(name: "George Michael Bluth")
       expect(@user.response_errors).to eq(%w(Yes Sir))
+    end
+
+    it "handles metadata on a destroyed resource" do
+      @user = User.destroy_existing(1)
+      @user.metadata[:foo].should == "bar"
+    end
+
+    it "handles error data on a destroyed resource" do
+      @user = User.destroy_existing(1)
+      @user.response_errors.should == ["Yes", "Sir"]
     end
   end
 


### PR DESCRIPTION
hello!

I've noticed that, as opposed to `#create`, `#save` and `#save_existing`, the `#destroy_existing` method does not expose metadata or response errors.

both are important to us (and I'd say in general), because a destroy action might fail in different ways and we'd like to have access to the particular error codes. same goes for the metadata.

sooo I've made this little PR and would appreciate your feedback :baby_chick: 
