### PR TITLE
Update RSpec to latest

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---colour --format=Fivemat
+--colour --format=documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1291 @@
+# This is the default configuration file. Enabling and disabling is configured
+# in separate files. This file adds all other parameters apart from Enabled.
+
+inherit_from:
+  # - enabled.yml
+  # - disabled.yml
+
+# Common configuration.
+AllCops:
+  # Include common Ruby source files.
+  Include:
+    - '**/*.gemspec'
+    - '**/*.podspec'
+    - '**/*.jbuilder'
+    - '**/*.rake'
+    - '**/*.opal'
+    - '**/config.ru'
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - '**/Capfile'
+    - '**/Guardfile'
+    - '**/Podfile'
+    - '**/Thorfile'
+    - '**/Vagrantfile'
+    - '**/Berksfile'
+    - '**/Cheffile'
+    - '**/Vagabondfile'
+    - '**/Fastfile'
+    - '**/*Fastfile'
+  Exclude:
+    - 'vendor/**/*'
+  # Default formatter will be used if no -f/--format option is given.
+  DefaultFormatter: progress
+  # Cop names are not displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
+  # option.
+  DisplayCopNames: false
+  # Style guide URLs are not displayed in offense messages by default. Change
+  # behavior by overriding DisplayStyleGuide, or by giving the
+  # -S/--display-style-guide option.
+  DisplayStyleGuide: false
+  # When specifying style guide URLs, any paths and/or fragments will be
+  # evaluated relative to the base URL.
+  # StyleGuideBaseURL: https://github.com/bbatsov/ruby-style-guide
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # -E/--extra-details option.
+  ExtraDetails: false
+  # Additional cops that do not reference a style guide rule may be enabled by
+  # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
+  # the --only-guide-cops option.
+  StyleGuideCopsOnly: false
+  # All cops except the ones in disabled.yml are enabled by default. Change
+  # this behavior by overriding DisabledByDefault. When DisabledByDefault is
+  # true, all cops in the default configuration are disabled, and and only cops
+  # in user configuration are enabled. This makes cops opt-in instead of
+  # opt-out. Note that when DisabledByDefault is true, cops in user
+  # configuration will be enabled even if they don't set the Enabled parameter.
+  DisabledByDefault: false
+  # Enables the result cache if true. Can be overridden by the --cache command
+  # line option.
+  UseCache: true
+  # Threshold for how many files can be stored in the result cache before some
+  # of the files are automatically removed.
+  MaxFilesInCache: 20000
+  # The cache will be stored in "rubocop_cache" under this directory. The name
+  # "/tmp" is special and will be converted to the system temporary directory,
+  # which is "/tmp" on Unix-like systems, but could be something else on other
+  # systems.
+  CacheRootDirectory: /tmp
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: false
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: ~
+
+# Indent private/protected/public as deep as method definitions
+Style/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+    - outdent
+    - indent
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
+
+# Align the elements of a hash literal if they span more than one line.
+Style/AlignHash:
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   'a' => 2
+  #   'bb' => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    'a' => 2
+  #   'bb' => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   'a'  => 2
+  #   'bb' => 3
+  EnforcedHashRocketStyle: key
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
+  EnforcedColonStyle: key
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
+
+Style/AlignParameters:
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/AndOr:
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - conditionals
+
+
+# Checks if usage of %() or %Q() matches configuration.
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+    - percent_q
+    - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+    # The `line_count_based` style enforces braces around single line blocks and
+    # do..end around multi-line blocks.
+    - line_count_based
+    # The `semantic` style enforces braces around functional blocks, where the
+    # primary purpose of the block is to return a value and do..end for
+    # procedural blocks, where the primary purpose of the block is its
+    # side-effects.
+    #
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+  SupportedStyles:
+    # The `braces` style enforces braces around all method parameters that are
+    # hashes.
+    - braces
+    # The `no_braces` style checks that the last parameter doesn't have braces
+    # around it.
+    - no_braces
+    # The `context_dependent` style checks that the last parameter doesn't have
+    # braces around it, but requires braces if the second to last parameter is
+    # also a hash literal.
+    - context_dependent
+
+# Indentation of `when`.
+Style/CaseIndentation:
+  IndentWhenRelativeTo: case
+  SupportedStyles:
+    - case
+    - end
+  IndentOneStep: false
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # This only matters if IndentOneStep is true
+  IndentationWidth: ~
+
+Style/ClassAndModuleChildren:
+  # Checks the style of children definitions at classes and modules.
+  #
+  # Basically there are two different styles:
+  #
+  # `nested` - have each child on a separate line
+  #   class Foo
+  #     class Bar
+  #     end
+  #   end
+  #
+  # `compact` - combine definitions as much as possible
+  #   class Foo::Bar
+  #   end
+  #
+  # The compact style is only forced, for classes / modules with one child.
+  EnforcedStyle: nested
+  SupportedStyles:
+    - nested
+    - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+    - is_a?
+    - kind_of?
+
+# Align with the style guide.
+Style/CollectionMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `detect` over `find`:
+  #
+  # CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+
+# Use ` or %x around command literals.
+Style/CommandLiteral:
+  EnforcedStyle: backticks
+  # backticks: Always use backticks.
+  # percent_x: Always use %x.
+  # mixed: Use backticks on single-line commands, and %x on multi-line commands.
+  SupportedStyles:
+    - backticks
+    - percent_x
+    - mixed
+  # If false, the cop will always recommend using %x if one or more backticks
+  # are found in the command string.
+  AllowInnerBackticks: false
+
+# Checks formatting of special comments
+Style/CommentAnnotation:
+  Keywords:
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+    - assign_to_condition
+    - assign_inside_condition
+  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
+  # will only register an offense when all branches of a condition are
+  # a single line.
+  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
+  # will only register an offense for assignment to a condition that has
+  # at least one multiline branch.
+  SingleLineConditionsOnly: true
+
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# AutocorrectNotice key that matches the regexp Notice.  A blank
+# AutocorrectNotice will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
+#
+Style/Copyright:
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  AutocorrectNotice: ''
+
+Style/DocumentationMethod:
+  RequireForNonPublicMethods: false
+
+# Multi-line method chaining should be done with leading dots.
+Style/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+    - leading
+    - trailing
+
+# Warn on empty else statements
+# empty - warn only on empty else
+# nil - warn on else with nil in it
+# both - warn on empty else and else with nil in it
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    - empty
+    - nil
+    - both
+
+# Use empty lines between defs.
+Style/EmptyLineBetweenDefs:
+  # If true, this parameter means that single line method definitions don't
+  # need an empty line between them.
+  AllowAdjacentOneLineDefs: false
+
+Style/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Style/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Style/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+# Checks whether the source file has a utf-8 encoding comment or not
+# AutoCorrectEncodingComment must match the regex
+# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+Style/Encoding:
+  EnforcedStyle: never
+  SupportedStyles:
+    - when_needed
+    - always
+    - never
+  AutoCorrectEncodingComment: '# encoding: utf-8'
+
+Style/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
+
+Style/FileName:
+  # File names listed in AllCops:Include are excluded by default. Add extra
+  # excludes here.
+  Exclude: []
+  # When true, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-nil, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
+
+Style/FirstParameterIndentation:
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as special_for_inner_method_call except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks use of for or each in multiline loops.
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+    - for
+    - each
+
+# Enforce the method used for string formatting.
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+    - format
+    - sprintf
+    - percent
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: when_needed
+  SupportedStyles:
+    # `when_needed` will add the frozen string literal comment to files
+    # only when the `TargetRubyVersion` is set to 2.3+.
+    - when_needed
+    # `always` will always add the frozen string literal comment to a file
+    # regardless of the Ruby version or if `freeze` or `<<` are called on a
+    # string literal. If you run code against multiple versions of Ruby, it is
+    # possible that this will create errors in Ruby 2.3.0+.
+    - always
+
+# Built-in global variables are allowed by default.
+Style/GlobalVars:
+  AllowedVariables: []
+
+# `MinBodyLength` defines the number of lines of the a body of an if / unless
+# needs to have to trigger this cop
+Style/GuardClause:
+  MinBodyLength: 1
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
+    - ruby19
+    # checks for hash rocket syntax for all hashes
+    - hash_rockets
+    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
+    - no_mixed_keys
+    # enforces both ruby19 and no_mixed_keys styles
+    - ruby19_no_mixed_keys
+  # Force hashes that have a symbol value to use hash rockets
+  UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Style/IfUnlessModifier:
+  MaxLineLength: 80
+
+Style/IndentationConsistency:
+  # The difference between `rails` and `normal` is that the `rails` style
+  # prescribes that in classes and modules the `protected` and `private`
+  # modifier keywords shall be indented the same as public methods and that
+  # protected and private members shall be indented one step more than the
+  # modifiers. Other than that, both styles mean that entities on the same
+  # logical depth shall have the same indentation.
+  EnforcedStyle: normal
+  SupportedStyles:
+    - normal
+    - rails
+
+Style/IndentationWidth:
+  # Number of spaces for each indentation level.
+  Width: 2
+
+# Checks the indentation of the first element in an array literal.
+Style/IndentArray:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Style/IndentAssignment:
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of the first key in a hash literal.
+Style/IndentHash:
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+    - call
+    - braces
+
+Style/Next:
+  # With `always` all conditions at the end of an iteration needs to be
+  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
+  # are ignored: [1, 2].each { |a| return 'yes' if a == 1 }
+  EnforcedStyle: skip_modifier_ifs
+  # `MinBodyLength` defines the number of lines of the a body of an if / unless
+  # needs to have to trigger this cop
+  MinBodyLength: 3
+  SupportedStyles:
+    - skip_modifier_ifs
+    - always
+
+Style/NonNilCheck:
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
+  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
+  # **usually** OK, but might change behavior.
+  #
+  # With `IncludeSemanticChanges` set to `false`, this cop does not report
+  # offenses for `!x.nil?` and does no changes that might change behavior.
+  IncludeSemanticChanges: false
+
+Style/NumericPredicate:
+  EnforcedStyle: predicate
+  SupportedStyles:
+    - predicate
+    - comparison
+  # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
+  # false positives.
+  Exclude:
+    - 'spec/**/*'
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+    - require_no_parentheses_except_multiline
+
+Style/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Style/ModuleFunction:
+  EnforcedStyle: module_function
+  SupportedStyles:
+    - module_function
+    - extend_self
+
+Style/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Style/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/NumericLiterals:
+  MinDigits: 5
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+    - zero_with_o
+    - zero_only
+
+Style/OptionHash:
+  # A list of parameter names that will be flagged by this cop.
+  SuspiciousParamNames:
+    - options
+    - opts
+    - args
+    - params
+    - parameters
+
+# Allow safe assignment in conditions.
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%':  ()
+    '%i': ()
+    '%q': ()
+    '%Q': ()
+    '%r': '{}'
+    '%s': ()
+    '%w': ()
+    '%W': ()
+    '%x': ()
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+    - lower_case_q # Use %q when possible, %Q when necessary
+    - upper_case_q # Always use %Q
+
+Style/PredicateName:
+  # Predicate name prefixes.
+  NamePrefix:
+    - is_
+    - has_
+    - have_
+  # Predicate name prefixes that should be removed.
+  NamePrefixBlacklist:
+    - is_
+    - has_
+    - have_
+  # Predicate names which, despite having a blacklisted prefix, or no ?,
+  # should still be accepted
+  NameWhitelist:
+    - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - 'spec/**/*'
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+    - compact # raise Exception.new(msg)
+    - exploded # raise Exception, msg
+
+Style/RedundantReturn:
+  # When true allows code like `return x, y`.
+  AllowMultipleReturnValues: false
+
+# Use / or %r around regular expressions.
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  # slashes: Always use slashes.
+  # percent_r: Always use %r.
+  # mixed: Use slashes on single-line regexes, and %r on multi-line regexes.
+  SupportedStyles:
+    - slashes
+    - percent_r
+    - mixed
+  # If false, the cop will always recommend using %r if one or more slashes
+  # are found in the regexp string.
+  AllowInnerSlashes: false
+
+# Style/SafeNavigation:
+#   # Safe navigation may cause a statement to start returning `nil` in addition
+#   # to whatever it used to return.
+#   ConvertCodeThatCanStartToReturnNil: false
+
+Style/Semicolon:
+  # Allow ; to separate several expressions on the same line.
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+    - only_raise
+    - only_fail
+    - semantic
+
+Style/SingleLineBlockParams:
+  Methods:
+    - reduce:
+        - a
+        - e
+    - inject:
+        - a
+        - e
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Style/SpaceBeforeFirstArg:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+    - use_perl_names
+    - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+  # If true, strings which span multiple lines using \ for continuation must
+  # use the same type of quotes on each line.
+  ConsistentQuotesInMultiline: false
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+
+Style/StringMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `to_sym` over `intern`:
+  #
+  # StringMethods:
+  #   PreferredMethods:
+  #     intern: to_sym
+  PreferredMethods:
+    intern: to_sym
+
+Style/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceAroundOperators:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
+
+Style/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  # Valid values are: space, no_space
+  EnforcedStyleForEmptyBraces: no_space
+  # Space between { and |. Overrides EnforcedStyle if there is a conflict.
+  SpaceBeforeBlockParameters: true
+
+Style/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    # 'compact' normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
+
+Style/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/SymbolArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    - percent
+    - brackets
+
+Style/SymbolProc:
+  # A list of method names to be ignored by the check.
+  # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
+  IgnoredMethods:
+    - respond_to
+    - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+  AllowSafeAssignment: true
+
+Style/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+    - final_newline
+    - final_blank_line
+
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+
+Style/TrailingCommaInLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+
+# TrivialAccessors requires exact name matches and doesn't allow
+# predicated methods by default.
+Style/TrivialAccessors:
+  # When set to false the cop will suggest the use of accessor methods
+  # in situations like:
+  #
+  # def name
+  #   @other_name
+  # end
+  #
+  # This way you can uncover "hidden" attributes in your code.
+  ExactNameMatch: true
+  AllowPredicates: true
+  # Allows trivial writers that don't end in an equal sign. e.g.
+  #
+  # def on_exception(action)
+  #   @on_exception=action
+  # end
+  # on_exception :restart
+  #
+  # Commonly used in DSLs
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  Whitelist:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
+
+Style/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Style/VariableNumber:
+  EnforcedStyle: normalcase
+  SupportedStyles:
+    - snake_case
+    - normalcase
+    - non_integer
+
+Style/WhileUntilModifier:
+  MaxLineLength: 80
+
+# WordArray enforces how array literals of word-like strings should be expressed.
+Style/WordArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    # percent style: %w(word1 word2)
+    - percent
+    # bracket style: ['word1', 'word2']
+    - brackets
+  # The MinSize option causes the WordArray rule to be ignored for arrays
+  # smaller than a certain size.  The rule is only applied to arrays
+  # whose element count is greater than or equal to MinSize.
+  MinSize: 0
+  # The regular expression WordRegex decides what is considered a word.
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+
+##################### Metrics ##################################
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
+  Max: 15
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/ClassLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+
+Metrics/ModuleLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+
+# Avoid complex methods.
+Metrics/CyclomaticComplexity:
+  Max: 6
+
+Metrics/LineLength:
+  Max: 120
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 10
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: true
+
+Metrics/PerceivedComplexity:
+  Max: 7
+
+##################### Lint ##################################
+
+# Allow safe assignment in conditions.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: true
+
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Lint/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  AlignWith: either
+  SupportedStyles:
+    - either
+    - start_of_block
+    - start_of_line
+
+# Align ends correctly.
+Lint/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  AlignWith: keyword
+  SupportedStyles:
+    - keyword
+    - variable
+    - start_of_line
+  AutoCorrect: false
+
+Lint/DefEndAlignment:
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
+  AlignWith: start_of_line
+  SupportedStyles:
+    - start_of_line
+    - def
+  AutoCorrect: false
+
+Lint/InheritException:
+  # The default base class in favour of `Exception`.
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+    - runtime_error
+    - standard_error
+
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+# Checks for unused method arguments.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+##################### Performance ############################
+
+Performance/RedundantMerge:
+  # Max number of key-value pairs to consider an offense
+  MaxKeyValuePairs: 2
+
+##################### Rails ##################################
+
+Rails/ActionFilter:
+  EnforcedStyle: action
+  SupportedStyles:
+    - action
+    - filter
+  Include:
+    - app/controllers/**/*.rb
+
+Rails/Date:
+  # The value `strict` disallows usage of `Date.today`, `Date.current`,
+  # `Date#to_time` etc.
+  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
+  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
+  # time zone.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/Exit:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+  Exclude:
+    - lib/**/*.rake
+
+Rails/FindBy:
+  Include:
+    - app/models/**/*.rb
+
+Rails/FindEach:
+  Include:
+    - app/models/**/*.rb
+
+Rails/HasAndBelongsToMany:
+  Include:
+    - app/models/**/*.rb
+
+Rails/NotNullColumn:
+  Include:
+    - db/migrate/*.rb
+
+Rails/Output:
+  Include:
+    - app/**/*.rb
+    - config/**/*.rb
+    - db/**/*.rb
+    - lib/**/*.rb
+
+Rails/ReadWriteAttribute:
+  Include:
+    - app/models/**/*.rb
+
+Rails/RequestReferer:
+  EnforcedStyle: referer
+  SupportedStyles:
+    - referer
+    - referrer
+
+Rails/SafeNavigation:
+  # This will convert usages of `try` to use safe navigation as well as `try!`.
+  # `try` and `try!` work slighly differently. `try!` and safe navigation will
+  # both raise a `NoMethodError` if the receiver of the method call does not
+  # implement the intended method. `try` will not raise an exception for this.
+  ConvertTry: false
+
+Rails/ScopeArgs:
+  Include:
+    - app/models/**/*.rb
+
+Rails/TimeZone:
+  # The value `strict` means that `Time` should be used with `zone`.
+  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
+  EnforcedStyle: flexible
+  SupportedStyles:
+    - strict
+    - flexible
+
+Rails/UniqBeforePluck:
+  EnforcedMode: conservative
+  SupportedModes:
+    - conservative
+    - aggressive
+  AutoCorrect: false
+
+Rails/Validation:
+  Include:
+    - app/models/**/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 sudo: false
 
 rvm:
+  - 2.3.1
   - 2.2.2
   - 2.1.6
   - 2.0.0

--- a/her.gemspec
+++ b/her.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency "rake", "~> 10.0"
-  s.add_development_dependency "rspec", "~> 2.13"
-  s.add_development_dependency "rspec-its", "~> 1.0"
-  s.add_development_dependency "fivemat", "~> 1.2"
+  s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "json", "~> 1.8"
 
   s.add_runtime_dependency "activemodel", ">= 3.0.0", "<= 6.0.0"

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -43,7 +43,7 @@ describe Her::API do
         before do
           subject.setup url: "https://api.example.com" do |builder|
             builder.use SimpleParser
-            builder.adapter(:test) { |stub| stub.get("/foo") { |_env| [200, {}, "Foo, it is."] } }
+            builder.adapter(:test) { |stub| stub.get("/foo") { [200, {}, "Foo, it is."] } }
           end
         end
 
@@ -69,7 +69,7 @@ describe Her::API do
           subject.setup url: "https://api.example.com" do |builder|
             builder.use Her::Middleware::FirstLevelParseJSON
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |_env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth", errors: ["This is a single error"], metadata: { page: 1, per_page: 10 })] }
+              stub.get("/users/1") { [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth", errors: ["This is a single error"], metadata: { page: 1, per_page: 10 })] }
             end
           end
         end
@@ -101,7 +101,7 @@ describe Her::API do
             builder.use CustomParser
             builder.use Faraday::Request::UrlEncoded
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |_env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth")] }
+              stub.get("/users/1") { [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth")] }
             end
           end
         end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -8,8 +8,8 @@ describe Her::API do
     describe "#setup" do
       context "when setting custom middleware" do
         before do
-          class Foo; end;
-          class Bar; end;
+          class Foo; end
+          class Bar; end
 
           subject.setup url: "https://api.example.com" do |connection|
             connection.use Foo
@@ -23,8 +23,8 @@ describe Her::API do
       context "when setting custom options" do
         before { subject.setup foo: { bar: "baz" }, url: "https://api.example.com" }
 
-        describe '#options' do
-          it { expect(subject.options).to eq({ foo: { bar: "baz" }, url: "https://api.example.com" }) }
+        describe "#options" do
+          it { expect(subject.options).to eq(foo: { bar: "baz" }, url: "https://api.example.com") }
         end
       end
     end
@@ -43,7 +43,7 @@ describe Her::API do
         before do
           subject.setup url: "https://api.example.com" do |builder|
             builder.use SimpleParser
-            builder.adapter(:test) { |stub| stub.get("/foo") { |env| [200, {}, "Foo, it is."] } }
+            builder.adapter(:test) { |stub| stub.get("/foo") { |_env| [200, {}, "Foo, it is."] } }
           end
         end
 
@@ -56,7 +56,7 @@ describe Her::API do
         before do
           subject.setup url: "https://api.example.com" do |builder|
             builder.use SimpleParser
-            builder.adapter(:test) { |stub| stub.get("/foo") { |env| [200, {}, "Foo, it is page #{env[:request_headers]["X-Page"]}."] } }
+            builder.adapter(:test) { |stub| stub.get("/foo") { |env| [200, {}, "Foo, it is page #{env[:request_headers]['X-Page']}."] } }
           end
         end
 
@@ -69,15 +69,15 @@ describe Her::API do
           subject.setup url: "https://api.example.com" do |builder|
             builder.use Her::Middleware::FirstLevelParseJSON
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |env| [200, {}, MultiJson.dump({ id: 1, name: "George Michael Bluth", errors: ["This is a single error"], metadata: { page: 1, per_page: 10 } })] }
+              stub.get("/users/1") { |_env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth", errors: ["This is a single error"], metadata: { page: 1, per_page: 10 })] }
             end
           end
         end
 
         specify do
-          expect(parsed_data[:data]).to eq({ id: 1, name: "George Michael Bluth" })
+          expect(parsed_data[:data]).to eq(id: 1, name: "George Michael Bluth")
           expect(parsed_data[:errors]).to eq(["This is a single error"])
-          expect(parsed_data[:metadata]).to eq({ page: 1, per_page: 10 })
+          expect(parsed_data[:metadata]).to eq(page: 1, per_page: 10)
         end
       end
 
@@ -92,7 +92,7 @@ describe Her::API do
               env[:body] = {
                 data: json,
                 errors: errors,
-                metadata: metadata,
+                metadata: metadata
               }
             end
           end
@@ -101,13 +101,13 @@ describe Her::API do
             builder.use CustomParser
             builder.use Faraday::Request::UrlEncoded
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth")] }
+              stub.get("/users/1") { |_env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth")] }
             end
           end
         end
 
         specify do
-          expect(parsed_data[:data]).to eq({ id: 1, name: "George Michael Bluth" })
+          expect(parsed_data[:data]).to eq(id: 1, name: "George Michael Bluth")
           expect(parsed_data[:errors]).to eq([])
           expect(parsed_data[:metadata]).to eq({})
         end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -11,7 +11,7 @@ describe Her::API do
           class Foo; end;
           class Bar; end;
 
-          subject.setup :url => "https://api.example.com" do |connection|
+          subject.setup url: "https://api.example.com" do |connection|
             connection.use Foo
             connection.use Bar
           end
@@ -21,10 +21,10 @@ describe Her::API do
       end
 
       context "when setting custom options" do
-        before { subject.setup :foo => { :bar => "baz" }, :url => "https://api.example.com" }
+        before { subject.setup foo: { bar: "baz" }, url: "https://api.example.com" }
 
         describe '#options' do
-          it { expect(subject.options).to eq({ :foo => { :bar => "baz" }, :url => "https://api.example.com" }) }
+          it { expect(subject.options).to eq({ foo: { bar: "baz" }, url: "https://api.example.com" }) }
         end
       end
     end
@@ -33,15 +33,15 @@ describe Her::API do
       before do
         class SimpleParser < Faraday::Response::Middleware
           def on_complete(env)
-            env[:body] = { :data => env[:body] }
+            env[:body] = { data: env[:body] }
           end
         end
       end
 
       context "making HTTP requests" do
-        let(:parsed_data) { subject.request(:_method => :get, :_path => "/foo")[:parsed_data] }
+        let(:parsed_data) { subject.request(_method: :get, _path: "/foo")[:parsed_data] }
         before do
-          subject.setup :url => "https://api.example.com" do |builder|
+          subject.setup url: "https://api.example.com" do |builder|
             builder.use SimpleParser
             builder.adapter(:test) { |stub| stub.get("/foo") { |env| [200, {}, "Foo, it is."] } }
           end
@@ -51,10 +51,10 @@ describe Her::API do
       end
 
       context "making HTTP requests while specifying custom HTTP headers" do
-        let(:parsed_data) { subject.request(:_method => :get, :_path => "/foo", :_headers => { "X-Page" => 2 })[:parsed_data] }
+        let(:parsed_data) { subject.request(_method: :get, _path: "/foo", _headers: { "X-Page" => 2 })[:parsed_data] }
 
         before do
-          subject.setup :url => "https://api.example.com" do |builder|
+          subject.setup url: "https://api.example.com" do |builder|
             builder.use SimpleParser
             builder.adapter(:test) { |stub| stub.get("/foo") { |env| [200, {}, "Foo, it is page #{env[:request_headers]["X-Page"]}."] } }
           end
@@ -64,50 +64,50 @@ describe Her::API do
       end
 
       context "parsing a request with the default parser" do
-        let(:parsed_data) { subject.request(:_method => :get, :_path => "users/1")[:parsed_data] }
+        let(:parsed_data) { subject.request(_method: :get, _path: "users/1")[:parsed_data] }
         before do
-          subject.setup :url => "https://api.example.com" do |builder|
+          subject.setup url: "https://api.example.com" do |builder|
             builder.use Her::Middleware::FirstLevelParseJSON
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |env| [200, {}, MultiJson.dump({ :id => 1, :name => "George Michael Bluth", :errors => ["This is a single error"], :metadata => { :page => 1, :per_page => 10 } })] }
+              stub.get("/users/1") { |env| [200, {}, MultiJson.dump({ id: 1, name: "George Michael Bluth", errors: ["This is a single error"], metadata: { page: 1, per_page: 10 } })] }
             end
           end
         end
 
         specify do
-          expect(parsed_data[:data]).to eq({ :id => 1, :name => "George Michael Bluth" })
+          expect(parsed_data[:data]).to eq({ id: 1, name: "George Michael Bluth" })
           expect(parsed_data[:errors]).to eq(["This is a single error"])
-          expect(parsed_data[:metadata]).to eq({ :page => 1, :per_page => 10 })
+          expect(parsed_data[:metadata]).to eq({ page: 1, per_page: 10 })
         end
       end
 
       context "parsing a request with a custom parser" do
-        let(:parsed_data) { subject.request(:_method => :get, :_path => "users/1")[:parsed_data] }
+        let(:parsed_data) { subject.request(_method: :get, _path: "users/1")[:parsed_data] }
         before do
           class CustomParser < Faraday::Response::Middleware
             def on_complete(env)
-              json = MultiJson.load(env[:body], :symbolize_keys => true)
+              json = MultiJson.load(env[:body], symbolize_keys: true)
               errors = json.delete(:errors) || []
               metadata = json.delete(:metadata) || {}
               env[:body] = {
-                :data => json,
-                :errors => errors,
-                :metadata => metadata,
+                data: json,
+                errors: errors,
+                metadata: metadata,
               }
             end
           end
 
-          subject.setup :url => "https://api.example.com" do |builder|
+          subject.setup url: "https://api.example.com" do |builder|
             builder.use CustomParser
             builder.use Faraday::Request::UrlEncoded
             builder.adapter :test do |stub|
-              stub.get("/users/1") { |env| [200, {}, MultiJson.dump(:id => 1, :name => "George Michael Bluth")] }
+              stub.get("/users/1") { |env| [200, {}, MultiJson.dump(id: 1, name: "George Michael Bluth")] }
             end
           end
         end
 
         specify do
-          expect(parsed_data[:data]).to eq({ :id => 1, :name => "George Michael Bluth" })
+          expect(parsed_data[:data]).to eq({ id: 1, name: "George Michael Bluth" })
           expect(parsed_data[:errors]).to eq([])
           expect(parsed_data[:metadata]).to eq({})
         end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -17,12 +17,15 @@ describe Her::API do
           end
         end
 
-        specify { subject.connection.builder.handlers.should == [Foo, Bar] }
+        specify { expect(subject.connection.builder.handlers).to eq([Foo, Bar]) }
       end
 
       context "when setting custom options" do
         before { subject.setup :foo => { :bar => "baz" }, :url => "https://api.example.com" }
-        its(:options) { should == { :foo => { :bar => "baz" }, :url => "https://api.example.com" } }
+
+        describe '#options' do
+          it { expect(subject.options).to eq({ :foo => { :bar => "baz" }, :url => "https://api.example.com" }) }
+        end
       end
     end
 
@@ -44,7 +47,7 @@ describe Her::API do
           end
         end
 
-        specify { parsed_data[:data].should == "Foo, it is." }
+        specify { expect(parsed_data[:data]).to eq("Foo, it is.") }
       end
 
       context "making HTTP requests while specifying custom HTTP headers" do
@@ -57,7 +60,7 @@ describe Her::API do
           end
         end
 
-        specify { parsed_data[:data].should == "Foo, it is page 2." }
+        specify { expect(parsed_data[:data]).to eq("Foo, it is page 2.") }
       end
 
       context "parsing a request with the default parser" do
@@ -72,9 +75,9 @@ describe Her::API do
         end
 
         specify do
-          parsed_data[:data].should == { :id => 1, :name => "George Michael Bluth" }
-          parsed_data[:errors].should == ["This is a single error"]
-          parsed_data[:metadata].should == { :page => 1, :per_page => 10 }
+          expect(parsed_data[:data]).to eq({ :id => 1, :name => "George Michael Bluth" })
+          expect(parsed_data[:errors]).to eq(["This is a single error"])
+          expect(parsed_data[:metadata]).to eq({ :page => 1, :per_page => 10 })
         end
       end
 
@@ -104,9 +107,9 @@ describe Her::API do
         end
 
         specify do
-          parsed_data[:data].should == { :id => 1, :name => "George Michael Bluth" }
-          parsed_data[:errors].should == []
-          parsed_data[:metadata].should == {}
+          expect(parsed_data[:data]).to eq({ :id => 1, :name => "George Michael Bluth" })
+          expect(parsed_data[:errors]).to eq([])
+          expect(parsed_data[:metadata]).to eq({})
         end
       end
     end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -1,10 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Her::Collection do
-
   let(:items) { [1, 2, 3, 4] }
-  let(:metadata) { { name: 'Testname' } }
-  let(:errors) { { name: ['not_present'] } }
+  let(:metadata) { { name: "Testname" } }
+  let(:errors) { { name: ["not_present"] } }
 
   describe "#new" do
     context "without parameters" do
@@ -12,12 +11,12 @@ describe Her::Collection do
 
       it { is_expected.to eq([]) }
 
-      describe '#metadata' do
+      describe "#metadata" do
         subject { super().metadata }
         it { is_expected.to eq({}) }
       end
 
-      describe '#errors' do
+      describe "#errors" do
         subject { super().errors }
         it { is_expected.to eq({}) }
       end
@@ -26,16 +25,16 @@ describe Her::Collection do
     context "with parameters" do
       subject { Her::Collection.new(items, metadata, errors) }
 
-      it { is_expected.to eq([1,2,3,4]) }
+      it { is_expected.to eq([1, 2, 3, 4]) }
 
-      describe '#metadata' do
+      describe "#metadata" do
         subject { super().metadata }
-        it { is_expected.to eq({ name: 'Testname' }) }
+        it { is_expected.to eq(name: "Testname") }
       end
 
-      describe '#errors' do
+      describe "#errors" do
         subject { super().errors }
-        it { is_expected.to eq({ name: ['not_present'] }) }
+        it { is_expected.to eq(name: ["not_present"]) }
       end
     end
   end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -10,17 +10,33 @@ describe Her::Collection do
     context "without parameters" do
       subject { Her::Collection.new }
 
-      it { should eq([]) }
-      its(:metadata) { should eq({}) }
-      its(:errors) { should eq({}) }
+      it { is_expected.to eq([]) }
+
+      describe '#metadata' do
+        subject { super().metadata }
+        it { is_expected.to eq({}) }
+      end
+
+      describe '#errors' do
+        subject { super().errors }
+        it { is_expected.to eq({}) }
+      end
     end
 
     context "with parameters" do
       subject { Her::Collection.new(items, metadata, errors) }
 
-      it { should eq([1,2,3,4]) }
-      its(:metadata) { should eq({ :name => 'Testname' }) }
-      its(:errors) { should eq({ :name => ['not_present'] }) }
+      it { is_expected.to eq([1,2,3,4]) }
+
+      describe '#metadata' do
+        subject { super().metadata }
+        it { is_expected.to eq({ :name => 'Testname' }) }
+      end
+
+      describe '#errors' do
+        subject { super().errors }
+        it { is_expected.to eq({ :name => ['not_present'] }) }
+      end
     end
   end
 end

--- a/spec/collection_spec.rb
+++ b/spec/collection_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Her::Collection do
 
   let(:items) { [1, 2, 3, 4] }
-  let(:metadata) { { :name => 'Testname' } }
-  let(:errors) { { :name => ['not_present'] } }
+  let(:metadata) { { name: 'Testname' } }
+  let(:errors) { { name: ['not_present'] } }
 
   describe "#new" do
     context "without parameters" do
@@ -30,12 +30,12 @@ describe Her::Collection do
 
       describe '#metadata' do
         subject { super().metadata }
-        it { is_expected.to eq({ :name => 'Testname' }) }
+        it { is_expected.to eq({ name: 'Testname' }) }
       end
 
       describe '#errors' do
         subject { super().errors }
-        it { is_expected.to eq({ :name => ['not_present'] }) }
+        it { is_expected.to eq({ name: ['not_present'] }) }
       end
     end
   end

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -1,163 +1,162 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Her::JsonApi::Model do
   before do
-    Her::API.setup :url => "https://api.example.com" do |connection|
+    Her::API.setup url: "https://api.example.com" do |connection|
       connection.use Her::Middleware::JsonApiParser
       connection.adapter :test do |stub|
-        stub.get("/users/1") do |env| 
-          [ 
+        stub.get("/users/1") do |_env|
+          [
             200,
             {},
             {
               data: {
                 id:    1,
-                type: 'users',
+                type: "users",
                 attributes: {
-                  name: "Roger Federer",
-                },
+                  name: "Roger Federer"
+                }
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
-        stub.get("/users") do |env| 
-          [ 
+        stub.get("/users") do |_env|
+          [
             200,
             {},
             {
               data: [
                 {
                   id:    1,
-                  type: 'users',
+                  type: "users",
                   attributes: {
-                    name: "Roger Federer",
-                  },
-                }, 
+                    name: "Roger Federer"
+                  }
+                },
                 {
                   id:    2,
-                  type: 'users',
+                  type: "users",
                   attributes: {
-                    name: "Kei Nishikori",
-                  },
+                    name: "Kei Nishikori"
+                  }
                 }
               ]
             }.to_json
-          ] 
+          ]
         end
 
         stub.post("/users", data: {
-          type: 'users',
-          attributes: {
-            name: "Jeremy Lin",
-          },
-        }) do |env|
-          [ 
+                    type: "users",
+                    attributes: {
+                      name: "Jeremy Lin"
+                    }
+                  }) do |_env|
+          [
             201,
             {},
             {
               data: {
                 id:    3,
-                type: 'users',
+                type: "users",
                 attributes: {
-                  name: 'Jeremy Lin',
-                },
+                  name: "Jeremy Lin"
+                }
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
         stub.patch("/users/1", data: {
-          type: 'users',
-          id: 1,
-          attributes: {
-            name: "Fed GOAT",
-          },
-        }) do |env|
-          [ 
+                     type: "users",
+                     id: 1,
+                     attributes: {
+                       name: "Fed GOAT"
+                     }
+                   }) do |_env|
+          [
             200,
             {},
             {
               data: {
                 id:    1,
-                type: 'users',
+                type: "users",
                 attributes: {
-                  name: 'Fed GOAT',
-                },
+                  name: "Fed GOAT"
+                }
               }
-              
+
             }.to_json
-          ] 
+          ]
         end
 
-        stub.delete("/users/1") { |env|
-          [ 204, {}, {}, ] 
-        }
+        stub.delete("/users/1") do |_env|
+          [204, {}, {}]
+        end
       end
-
     end
 
     spawn_model("Foo::User", type: Her::JsonApi::Model)
   end
 
-  it 'allows configuration of type' do
+  it "allows configuration of type" do
     spawn_model("Foo::Bar", type: Her::JsonApi::Model) do
       type :foobars
     end
 
-    expect(Foo::Bar.instance_variable_get('@type')).to eql('foobars')
+    expect(Foo::Bar.instance_variable_get("@type")).to eql("foobars")
   end
 
-  it 'finds models by id' do
+  it "finds models by id" do
     user = Foo::User.find(1)
     expect(user.attributes).to eql(
-      'id' => 1,
-      'name' => 'Roger Federer',
+      "id" => 1,
+      "name" => "Roger Federer"
     )
   end
 
-  it 'finds a collection of models' do
+  it "finds a collection of models" do
     users = Foo::User.all
     expect(users.map(&:attributes)).to match_array([
-      {
-        'id' => 1,
-        'name' => 'Roger Federer',
-      },
-      {
-        'id' => 2,
-        'name' => 'Kei Nishikori',
-      }
-    ])
+                                                     {
+                                                       "id" => 1,
+                                                       "name" => "Roger Federer"
+                                                     },
+                                                     {
+                                                       "id" => 2,
+                                                       "name" => "Kei Nishikori"
+                                                     }
+                                                   ])
   end
 
-  it 'creates a Foo::User' do
-    user = Foo::User.new(name: 'Jeremy Lin')
+  it "creates a Foo::User" do
+    user = Foo::User.new(name: "Jeremy Lin")
     user.save
     expect(user.attributes).to eql(
-      'id' => 3,
-      'name' => 'Jeremy Lin',
+      "id" => 3,
+      "name" => "Jeremy Lin"
     )
   end
 
-  it 'updates a Foo::User' do
+  it "updates a Foo::User" do
     user = Foo::User.find(1)
-    user.name = 'Fed GOAT'
+    user.name = "Fed GOAT"
     user.save
     expect(user.attributes).to eql(
-      'id' => 1,
-      'name' => 'Fed GOAT',
+      "id" => 1,
+      "name" => "Fed GOAT"
     )
   end
 
-  it 'destroys a Foo::User' do
+  it "destroys a Foo::User" do
     user = Foo::User.find(1)
     expect(user.destroy).to be_destroyed
   end
 
-  context 'undefined methods' do
-    it 'removes methods that are not compatible with json api' do
+  context "undefined methods" do
+    it "removes methods that are not compatible with json api" do
       [:parse_root_in_json, :include_root_in_json, :root_element, :primary_key].each do |method|
         expect { Foo::User.new.send(method, :foo) }.to raise_error NoMethodError, "Her::JsonApi::Model does not support the #{method} configuration option"
       end

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -5,7 +5,7 @@ describe Her::JsonApi::Model do
     Her::API.setup url: "https://api.example.com" do |connection|
       connection.use Her::Middleware::JsonApiParser
       connection.adapter :test do |stub|
-        stub.get("/users/1") do |_env|
+        stub.get("/users/1") do
           [
             200,
             {},
@@ -22,7 +22,7 @@ describe Her::JsonApi::Model do
           ]
         end
 
-        stub.get("/users") do |_env|
+        stub.get("/users") do
           [
             200,
             {},
@@ -47,12 +47,13 @@ describe Her::JsonApi::Model do
           ]
         end
 
-        stub.post("/users", data: {
-                    type: "users",
-                    attributes: {
-                      name: "Jeremy Lin"
-                    }
-                  }) do |_env|
+        stub.post("/users", data:
+        {
+          type: "users",
+          attributes: {
+            name: "Jeremy Lin"
+          }
+        }) do
           [
             201,
             {},
@@ -69,13 +70,14 @@ describe Her::JsonApi::Model do
           ]
         end
 
-        stub.patch("/users/1", data: {
-                     type: "users",
-                     id: 1,
-                     attributes: {
-                       name: "Fed GOAT"
-                     }
-                   }) do |_env|
+        stub.patch("/users/1", data:
+        {
+          type: "users",
+          id: 1,
+          attributes: {
+            name: "Fed GOAT"
+          }
+        }) do
           [
             200,
             {},
@@ -92,7 +94,7 @@ describe Her::JsonApi::Model do
           ]
         end
 
-        stub.delete("/users/1") do |_env|
+        stub.delete("/users/1") do
           [204, {}, {}]
         end
       end
@@ -119,16 +121,18 @@ describe Her::JsonApi::Model do
 
   it "finds a collection of models" do
     users = Foo::User.all
-    expect(users.map(&:attributes)).to match_array([
-                                                     {
-                                                       "id" => 1,
-                                                       "name" => "Roger Federer"
-                                                     },
-                                                     {
-                                                       "id" => 2,
-                                                       "name" => "Kei Nishikori"
-                                                     }
-                                                   ])
+    expect(users.map(&:attributes)).to match_array(
+      [
+        {
+          "id" => 1,
+          "name" => "Roger Federer"
+        },
+        {
+          "id" => 2,
+          "name" => "Kei Nishikori"
+        }
+      ]
+    )
   end
 
   it "creates a Foo::User" do

--- a/spec/middleware/accept_json_spec.rb
+++ b/spec/middleware/accept_json_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 describe Her::Middleware::AcceptJSON do
   it "adds an Accept header" do
     described_class.new.add_header({}).tap do |headers|
-      headers["Accept"].should == "application/json"
+      expect(headers["Accept"]).to eq("application/json")
     end
   end
 end

--- a/spec/middleware/first_level_parse_json_spec.rb
+++ b/spec/middleware/first_level_parse_json_spec.rb
@@ -12,8 +12,8 @@ describe Her::Middleware::FirstLevelParseJSON do
 
   it "parses body as json" do
     subject.parse(body_without_errors).tap do |json|
-      json[:data].should == { :id => 1, :name => "Tobias Fünke" }
-      json[:metadata].should == 3
+      expect(json[:data]).to eq({ :id => 1, :name => "Tobias Fünke" })
+      expect(json[:metadata]).to eq(3)
     end
   end
 
@@ -21,17 +21,17 @@ describe Her::Middleware::FirstLevelParseJSON do
     env = { :body => body_without_errors }
     subject.on_complete(env)
     env[:body].tap do |json|
-      json[:data].should == { :id => 1, :name => "Tobias Fünke" }
-      json[:metadata].should == 3
+      expect(json[:data]).to eq({ :id => 1, :name => "Tobias Fünke" })
+      expect(json[:metadata]).to eq(3)
     end
   end
 
   it 'ensures the errors are a hash if there are no errors' do
-    subject.parse(body_without_errors)[:errors].should eq({})
+    expect(subject.parse(body_without_errors)[:errors]).to eq({})
   end
 
   it 'ensures the errors are a hash if there are no errors' do
-    subject.parse(body_with_errors)[:errors].should eq({:name => [ 'not_valid', 'should_be_present']})
+    expect(subject.parse(body_with_errors)[:errors]).to eq({:name => [ 'not_valid', 'should_be_present']})
   end
 
   it 'ensures that malformed JSON throws an exception' do
@@ -43,11 +43,11 @@ describe Her::Middleware::FirstLevelParseJSON do
   end
 
   it 'ensures that a nil response returns an empty hash' do
-    subject.parse(nil_body)[:data].should eq({})
+    expect(subject.parse(nil_body)[:data]).to eq({})
   end
 
   it 'ensures that an empty response returns an empty hash' do
-    subject.parse(empty_body)[:data].should eq({})
+    expect(subject.parse(empty_body)[:data]).to eq({})
   end
 
   context 'with status code 204' do
@@ -55,7 +55,7 @@ describe Her::Middleware::FirstLevelParseJSON do
       env = { :status => 204 }
       subject.on_complete(env)
       env[:body].tap do |json|
-        json[:data].should == { }
+        expect(json[:data]).to eq({ })
       end
     end
   end

--- a/spec/middleware/first_level_parse_json_spec.rb
+++ b/spec/middleware/first_level_parse_json_spec.rb
@@ -7,12 +7,12 @@ describe Her::Middleware::FirstLevelParseJSON do
   let(:body_with_errors) { "{\"id\": 1, \"name\": \"Tobias Fünke\", \"errors\": { \"name\": [ \"not_valid\", \"should_be_present\" ] }, \"metadata\": 3}" }
   let(:body_with_malformed_json) { "wut." }
   let(:body_with_invalid_json) { "true" }
-  let(:empty_body) { '' }
+  let(:empty_body) { "" }
   let(:nil_body) { nil }
 
   it "parses body as json" do
     subject.parse(body_without_errors).tap do |json|
-      expect(json[:data]).to eq({ id: 1, name: "Tobias Fünke" })
+      expect(json[:data]).to eq(id: 1, name: "Tobias Fünke")
       expect(json[:metadata]).to eq(3)
     end
   end
@@ -21,41 +21,41 @@ describe Her::Middleware::FirstLevelParseJSON do
     env = { body: body_without_errors }
     subject.on_complete(env)
     env[:body].tap do |json|
-      expect(json[:data]).to eq({ id: 1, name: "Tobias Fünke" })
+      expect(json[:data]).to eq(id: 1, name: "Tobias Fünke")
       expect(json[:metadata]).to eq(3)
     end
   end
 
-  it 'ensures the errors are a hash if there are no errors' do
+  it "ensures the errors are a hash if there are no errors" do
     expect(subject.parse(body_without_errors)[:errors]).to eq({})
   end
 
-  it 'ensures the errors are a hash if there are no errors' do
-    expect(subject.parse(body_with_errors)[:errors]).to eq({name: [ 'not_valid', 'should_be_present']})
+  it "ensures the errors are a hash if there are no errors" do
+    expect(subject.parse(body_with_errors)[:errors]).to eq(name: %w(not_valid should_be_present))
   end
 
-  it 'ensures that malformed JSON throws an exception' do
+  it "ensures that malformed JSON throws an exception" do
     expect { subject.parse(body_with_malformed_json) }.to raise_error(Her::Errors::ParseError, 'Response from the API must behave like a Hash or an Array (last JSON response was "wut.")')
   end
 
-  it 'ensures that invalid JSON throws an exception' do
+  it "ensures that invalid JSON throws an exception" do
     expect { subject.parse(body_with_invalid_json) }.to raise_error(Her::Errors::ParseError, 'Response from the API must behave like a Hash or an Array (last JSON response was "true")')
   end
 
-  it 'ensures that a nil response returns an empty hash' do
+  it "ensures that a nil response returns an empty hash" do
     expect(subject.parse(nil_body)[:data]).to eq({})
   end
 
-  it 'ensures that an empty response returns an empty hash' do
+  it "ensures that an empty response returns an empty hash" do
     expect(subject.parse(empty_body)[:data]).to eq({})
   end
 
-  context 'with status code 204' do
-    it 'returns an empty body' do
+  context "with status code 204" do
+    it "returns an empty body" do
       env = { status: 204 }
       subject.on_complete(env)
       env[:body].tap do |json|
-        expect(json[:data]).to eq({ })
+        expect(json[:data]).to eq({})
       end
     end
   end

--- a/spec/middleware/first_level_parse_json_spec.rb
+++ b/spec/middleware/first_level_parse_json_spec.rb
@@ -12,16 +12,16 @@ describe Her::Middleware::FirstLevelParseJSON do
 
   it "parses body as json" do
     subject.parse(body_without_errors).tap do |json|
-      expect(json[:data]).to eq({ :id => 1, :name => "Tobias Fünke" })
+      expect(json[:data]).to eq({ id: 1, name: "Tobias Fünke" })
       expect(json[:metadata]).to eq(3)
     end
   end
 
   it "parses :body key as json in the env hash" do
-    env = { :body => body_without_errors }
+    env = { body: body_without_errors }
     subject.on_complete(env)
     env[:body].tap do |json|
-      expect(json[:data]).to eq({ :id => 1, :name => "Tobias Fünke" })
+      expect(json[:data]).to eq({ id: 1, name: "Tobias Fünke" })
       expect(json[:metadata]).to eq(3)
     end
   end
@@ -31,7 +31,7 @@ describe Her::Middleware::FirstLevelParseJSON do
   end
 
   it 'ensures the errors are a hash if there are no errors' do
-    expect(subject.parse(body_with_errors)[:errors]).to eq({:name => [ 'not_valid', 'should_be_present']})
+    expect(subject.parse(body_with_errors)[:errors]).to eq({name: [ 'not_valid', 'should_be_present']})
   end
 
   it 'ensures that malformed JSON throws an exception' do
@@ -52,7 +52,7 @@ describe Her::Middleware::FirstLevelParseJSON do
 
   context 'with status code 204' do
     it 'returns an empty body' do
-      env = { :status => 204 }
+      env = { status: 204 }
       subject.on_complete(env)
       env[:body].tap do |json|
         expect(json[:data]).to eq({ })

--- a/spec/middleware/json_api_parser_spec.rb
+++ b/spec/middleware/json_api_parser_spec.rb
@@ -22,11 +22,10 @@ describe Her::Middleware::JsonApiParser do
     end
   end
 
-  #context "with invalid JSON body" do
+  # context "with invalid JSON body" do
   #  let(:body) { '"foo"' }
   #  it 'ensures that invalid JSON throws an exception' do
   #    expect { subject.parse(body) }.to raise_error(Her::Errors::ParseError, 'Response from the API must behave like a Hash or an Array (last JSON response was "\"foo\"")')
   #  end
-  #end
-
+  # end
 end

--- a/spec/middleware/json_api_parser_spec.rb
+++ b/spec/middleware/json_api_parser_spec.rb
@@ -12,12 +12,12 @@ describe Her::Middleware::JsonApiParser do
       subject.on_complete(env)
       env.fetch(:body).tap do |json|
         expect(json[:data]).to eql(
-          :type => "foo",
-          :id => "bar",
-          :attributes => { :baz => "qux" } 
+          type: "foo",
+          id: "bar",
+          attributes: { baz: "qux" }
         )
         expect(json[:errors]).to eql([])
-        expect(json[:metadata]).to eql(:api => "json api")
+        expect(json[:metadata]).to eql(api: "json api")
       end
     end
   end

--- a/spec/middleware/second_level_parse_json_spec.rb
+++ b/spec/middleware/second_level_parse_json_spec.rb
@@ -8,9 +8,9 @@ describe Her::Middleware::SecondLevelParseJSON do
     let(:body) { "{\"data\": 1, \"errors\": 2, \"metadata\": 3}" }
     it "parses body as json" do
       subject.parse(body).tap do |json|
-        json[:data].should == 1
-        json[:errors].should == 2
-        json[:metadata].should == 3
+        expect(json[:data]).to eq(1)
+        expect(json[:errors]).to eq(2)
+        expect(json[:metadata]).to eq(3)
       end
     end
 
@@ -18,9 +18,9 @@ describe Her::Middleware::SecondLevelParseJSON do
       env = { :body => body }
       subject.on_complete(env)
       env[:body].tap do |json|
-        json[:data].should == 1
-        json[:errors].should == 2
-        json[:metadata].should == 3
+        expect(json[:data]).to eq(1)
+        expect(json[:errors]).to eq(2)
+        expect(json[:metadata]).to eq(3)
       end
     end
   end

--- a/spec/middleware/second_level_parse_json_spec.rb
+++ b/spec/middleware/second_level_parse_json_spec.rb
@@ -15,7 +15,7 @@ describe Her::Middleware::SecondLevelParseJSON do
     end
 
     it "parses :body key as json in the env hash" do
-      env = { :body => body }
+      env = { body: body }
       subject.on_complete(env)
       env[:body].tap do |json|
         expect(json[:data]).to eq(1)

--- a/spec/middleware/second_level_parse_json_spec.rb
+++ b/spec/middleware/second_level_parse_json_spec.rb
@@ -27,9 +27,8 @@ describe Her::Middleware::SecondLevelParseJSON do
 
   context "with invalid JSON body" do
     let(:body) { '"foo"' }
-    it 'ensures that invalid JSON throws an exception' do
+    it "ensures that invalid JSON throws an exception" do
       expect { subject.parse(body) }.to raise_error(Her::Errors::ParseError, 'Response from the API must behave like a Hash or an Array (last JSON response was "\"foo\"")')
     end
   end
-
 end

--- a/spec/model/associations/association_proxy_spec.rb
+++ b/spec/model/associations/association_proxy_spec.rb
@@ -8,8 +8,8 @@ describe Her::Model::Associations::AssociationProxy do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
-          stub.get("/users/1/fish") { |_env| [200, {}, { id: 1, name: "Tobias's Fish" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+          stub.get("/users/1/fish") { [200, {}, { id: 1, name: "Tobias's Fish" }.to_json] }
         end
       end
       spawn_model "User" do

--- a/spec/model/associations/association_proxy_spec.rb
+++ b/spec/model/associations/association_proxy_spec.rb
@@ -8,8 +8,8 @@ describe Her::Model::Associations::AssociationProxy do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json ] }
-          stub.get("/users/1/fish") { |env| [200, {}, { :id => 1, :name => "Tobias's Fish" }.to_json ] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json ] }
+          stub.get("/users/1/fish") { |env| [200, {}, { id: 1, name: "Tobias's Fish" }.to_json ] }
         end
       end
       spawn_model "User" do
@@ -26,6 +26,3 @@ describe Her::Model::Associations::AssociationProxy do
     end
   end
 end
-
-
-

--- a/spec/model/associations/association_proxy_spec.rb
+++ b/spec/model/associations/association_proxy_spec.rb
@@ -8,8 +8,8 @@ describe Her::Model::Associations::AssociationProxy do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json ] }
-          stub.get("/users/1/fish") { |env| [200, {}, { id: 1, name: "Tobias's Fish" }.to_json ] }
+          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+          stub.get("/users/1/fish") { |_env| [200, {}, { id: 1, name: "Tobias's Fish" }.to_json] }
         end
       end
       spawn_model "User" do

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -128,18 +128,18 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", comments: [{ comment: { id: 2, body: "Tobias, you blow hard!", user_id: 1 } }, { comment: { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 } }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 2 }.to_json] }
-          stub.get("/users/1/comments") { |_env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }].to_json] }
-          stub.get("/users/2/comments") { |_env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }].to_json] }
-          stub.get("/users/2/comments/5") { |_env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/users/2/role") { |_env| [200, {}, { id: 2, body: "User" }.to_json] }
-          stub.get("/users/1/role") { |_env| [200, {}, { id: 3, body: "User" }.to_json] }
-          stub.get("/users/1/posts") { |_env| [200, {}, [{ id: 1, body: "blogging stuff", admin_id: 1 }].to_json] }
-          stub.get("/organizations/1") { |_env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
-          stub.post("/users") { |_env| [200, {}, { id: 5, name: "Mr. Krabs", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
-          stub.put("/users/5") { |_env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
-          stub.delete("/users/5") { |_env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke", comments: [{ comment: { id: 2, body: "Tobias, you blow hard!", user_id: 1 } }, { comment: { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 } }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("/users/1/comments") { [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }].to_json] }
+          stub.get("/users/2/comments") { [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }].to_json] }
+          stub.get("/users/2/comments/5") { [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/users/2/role") { [200, {}, { id: 2, body: "User" }.to_json] }
+          stub.get("/users/1/role") { [200, {}, { id: 3, body: "User" }.to_json] }
+          stub.get("/users/1/posts") { [200, {}, [{ id: 1, body: "blogging stuff", admin_id: 1 }].to_json] }
+          stub.get("/organizations/1") { [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
+          stub.post("/users") { [200, {}, { id: 5, name: "Mr. Krabs", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.put("/users/5") { [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.delete("/users/5") { [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
 
           stub.get("/organizations/2") do |env|
             if env[:params]["admin"] == "true"
@@ -318,12 +318,12 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, name: "Tobias Fünke", comments: [{ id: 2, body: "Tobias, you blow hard!", user_id: 1 }, { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 } }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { user: { id: 2, name: "Lindsay Fünke", organization_id: 1 } }.to_json] }
-          stub.get("/users/1/comments") { |_env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }] }.to_json] }
-          stub.get("/users/2/comments") { |_env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }, { id: 5, body: "Is this the tiny town from Footloose?" }] }.to_json] }
-          stub.get("/users/2/comments/5") { |_env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/organizations/1") { |_env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
+          stub.get("/users/1") { [200, {}, { user: { id: 1, name: "Tobias Fünke", comments: [{ id: 2, body: "Tobias, you blow hard!", user_id: 1 }, { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 } }.to_json] }
+          stub.get("/users/2") { [200, {}, { user: { id: 2, name: "Lindsay Fünke", organization_id: 1 } }.to_json] }
+          stub.get("/users/1/comments") { [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }] }.to_json] }
+          stub.get("/users/2/comments") { [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }, { id: 5, body: "Is this the tiny town from Footloose?" }] }.to_json] }
+          stub.get("/users/2/comments/5") { [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/organizations/1") { [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
         end
       end
       spawn_model "Foo::User" do
@@ -400,11 +400,11 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
-          stub.get("/users/4") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
-          stub.get("/users/3") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
-          stub.get("/companies/1") { |_env| [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
+          stub.get("/users/4") { [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
+          stub.get("/users/3") { [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
+          stub.get("/companies/1") { [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
         end
       end
 
@@ -510,7 +510,7 @@ describe Her::Model::Associations do
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/10") { |_env| [200, {}, { id: 10 }.to_json] }
+            stub.get("/users/10") { [200, {}, { id: 10 }.to_json] }
             stub.post("/comments") { |env| [200, {}, { id: 1, body: Faraday::Utils.parse_query(env[:body])["body"], user_id: Faraday::Utils.parse_query(env[:body])["user_id"].to_i }.to_json] }
           end
         end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -9,7 +9,7 @@ describe Her::Model::Associations do
     context "single has_many association" do
       before { Foo::User.has_many :comments }
 
-      describe '[:has_many]' do
+      describe "[:has_many]" do
         subject { super()[:has_many] }
         it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }] }
       end
@@ -21,7 +21,7 @@ describe Her::Model::Associations do
         Foo::User.has_many :posts
       end
 
-      describe '[:has_many]' do
+      describe "[:has_many]" do
         subject { super()[:has_many] }
         it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }, { name: :posts, data_key: :posts, default: [], class_name: "Post", path: "/posts", inverse_of: nil }] }
       end
@@ -30,7 +30,7 @@ describe Her::Model::Associations do
     context "single has_one association" do
       before { Foo::User.has_one :category }
 
-      describe '[:has_one]' do
+      describe "[:has_one]" do
         subject { super()[:has_one] }
         it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }] }
       end
@@ -42,7 +42,7 @@ describe Her::Model::Associations do
         Foo::User.has_one :role
       end
 
-      describe '[:has_one]' do
+      describe "[:has_one]" do
         subject { super()[:has_one] }
         it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }, { name: :role, data_key: :role, default: nil, class_name: "Role", path: "/role" }] }
       end
@@ -51,7 +51,7 @@ describe Her::Model::Associations do
     context "single belongs_to association" do
       before { Foo::User.belongs_to :organization }
 
-      describe '[:belongs_to]' do
+      describe "[:belongs_to]" do
         subject { super()[:belongs_to] }
         it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }] }
       end
@@ -63,7 +63,7 @@ describe Her::Model::Associations do
         Foo::User.belongs_to :family
       end
 
-      describe '[:belongs_to]' do
+      describe "[:belongs_to]" do
         subject { super()[:belongs_to] }
         it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }, { name: :family, data_key: :family, default: nil, class_name: "Family", foreign_key: "family_id", path: "/families/:id" }] }
       end
@@ -78,7 +78,7 @@ describe Her::Model::Associations do
       context "single has_many association" do
         before { Foo::User.has_many :comments, class_name: "Post", inverse_of: :admin, data_key: :user_comments, default: {} }
 
-        describe '[:has_many]' do
+        describe "[:has_many]" do
           subject { super()[:has_many] }
           it { is_expected.to eql [{ name: :comments, data_key: :user_comments, default: {}, class_name: "Post", path: "/comments", inverse_of: :admin }] }
         end
@@ -87,7 +87,7 @@ describe Her::Model::Associations do
       context "single has_one association" do
         before { Foo::User.has_one :category, class_name: "Topic", foreign_key: "topic_id", data_key: :topic, default: nil }
 
-        describe '[:has_one]' do
+        describe "[:has_one]" do
           subject { super()[:has_one] }
           it { is_expected.to eql [{ name: :category, data_key: :topic, default: nil, class_name: "Topic", foreign_key: "topic_id", path: "/category" }] }
         end
@@ -96,7 +96,7 @@ describe Her::Model::Associations do
       context "single belongs_to association" do
         before { Foo::User.belongs_to :organization, class_name: "Business", foreign_key: "org_id", data_key: :org, default: true }
 
-        describe '[:belongs_to]' do
+        describe "[:belongs_to]" do
           subject { super()[:belongs_to] }
           it { is_expected.to eql [{ name: :organization, data_key: :org, default: true, class_name: "Business", foreign_key: "org_id", path: "/organizations/:id" }] }
         end
@@ -109,12 +109,12 @@ describe Her::Model::Associations do
       describe "associations accessor" do
         subject { Class.new(Foo::User).associations }
 
-        describe '#object_id' do
+        describe "#object_id" do
           subject { super().object_id }
           it { is_expected.not_to eql Foo::User.associations.object_id }
         end
 
-        describe '[:has_many]' do
+        describe "[:has_many]" do
           subject { super()[:has_many] }
           it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Post", path: "/comments", inverse_of: nil }] }
         end
@@ -128,18 +128,18 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke", comments: [{ comment: { id: 2, body: "Tobias, you blow hard!", user_id: 1 } }, { comment: { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 } }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 2 }.to_json] }
-          stub.get("/users/1/comments") { |env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }].to_json] }
-          stub.get("/users/2/comments") { |env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }].to_json] }
-          stub.get("/users/2/comments/5") { |env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/users/2/role") { |env| [200, {}, { id: 2, body: "User" }.to_json] }
-          stub.get("/users/1/role") { |env| [200, {}, { id: 3, body: "User" }.to_json] }
-          stub.get("/users/1/posts") { |env| [200, {}, [{id: 1, body: 'blogging stuff', admin_id: 1 }].to_json] }
-          stub.get("/organizations/1") { |env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
-          stub.post("/users") { |env| [200, {}, { id: 5, name: "Mr. Krabs", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
-          stub.put("/users/5") { |env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
-          stub.delete("/users/5") { |env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", comments: [{ comment: { id: 2, body: "Tobias, you blow hard!", user_id: 1 } }, { comment: { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 } }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 }.to_json] }
+          stub.get("/users/2") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("/users/1/comments") { |_env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }].to_json] }
+          stub.get("/users/2/comments") { |_env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }].to_json] }
+          stub.get("/users/2/comments/5") { |_env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/users/2/role") { |_env| [200, {}, { id: 2, body: "User" }.to_json] }
+          stub.get("/users/1/role") { |_env| [200, {}, { id: 3, body: "User" }.to_json] }
+          stub.get("/users/1/posts") { |_env| [200, {}, [{ id: 1, body: "blogging stuff", admin_id: 1 }].to_json] }
+          stub.get("/organizations/1") { |_env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { id: 5, name: "Mr. Krabs", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.put("/users/5") { |_env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.delete("/users/5") { |_env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
 
           stub.get("/organizations/2") do |env|
             if env[:params]["admin"] == "true"
@@ -162,7 +162,7 @@ describe Her::Model::Associations do
         parse_root_in_json true
       end
       spawn_model "Foo::Post" do
-        belongs_to :admin, class_name: 'Foo::User'
+        belongs_to :admin, class_name: "Foo::User"
       end
 
       spawn_model "Foo::Organization" do
@@ -286,7 +286,7 @@ describe Her::Model::Associations do
       expect(@user_without_included_data.organization).not_to be_empty
     end
 
-    it 'includes has_many relationships in params by default' do
+    it "includes has_many relationships in params by default" do
       params = @user_with_included_data.to_params
       expect(params[:comments]).to be_kind_of(Array)
       expect(params[:comments].length).to eq(2)
@@ -294,7 +294,7 @@ describe Her::Model::Associations do
 
     [:create, :save_existing, :destroy].each do |type|
       context "after #{type}" do
-        let(:subject) { self.send("user_with_included_data_after_#{type}")}
+        let(:subject) { send("user_with_included_data_after_#{type}") }
 
         it "maps an array of included data through has_many" do
           expect(subject.comments.first).to be_a(Foo::Comment)
@@ -318,12 +318,12 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, name: "Tobias Fünke", comments: [{ id: 2, body: "Tobias, you blow hard!", user_id: 1 }, { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 } }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { user: { id: 2, name: "Lindsay Fünke", organization_id: 1 } }.to_json] }
-          stub.get("/users/1/comments") { |env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }] }.to_json] }
-          stub.get("/users/2/comments") { |env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }, { id: 5, body: "Is this the tiny town from Footloose?" }] }.to_json] }
-          stub.get("/users/2/comments/5") { |env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/organizations/1") { |env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, name: "Tobias Fünke", comments: [{ id: 2, body: "Tobias, you blow hard!", user_id: 1 }, { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 } }.to_json] }
+          stub.get("/users/2") { |_env| [200, {}, { user: { id: 2, name: "Lindsay Fünke", organization_id: 1 } }.to_json] }
+          stub.get("/users/1/comments") { |_env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }] }.to_json] }
+          stub.get("/users/2/comments") { |_env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }, { id: 5, body: "Is this the tiny town from Footloose?" }] }.to_json] }
+          stub.get("/users/2/comments/5") { |_env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/organizations/1") { |_env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
         end
       end
       spawn_model "Foo::User" do
@@ -387,7 +387,7 @@ describe Her::Model::Associations do
       expect(comment.id).to eq(5)
     end
 
-    it 'includes has_many relationships in params by default' do
+    it "includes has_many relationships in params by default" do
       params = @user_with_included_data.to_params
       expect(params[:comments]).to be_kind_of(Array)
       expect(params[:comments].length).to eq(2)
@@ -400,11 +400,11 @@ describe Her::Model::Associations do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
-          stub.get("/users/4") { |env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
-          stub.get("/users/3") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
-          stub.get("/companies/1") { |env| [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
+          stub.get("/users/4") { |_env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
+          stub.get("/users/2") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
+          stub.get("/users/3") { |_env| [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
+          stub.get("/companies/1") { |_env| [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
         end
       end
 
@@ -466,7 +466,7 @@ describe Her::Model::Associations do
 
     it "doesnt mask core methods like extend" do
       committer = Module.new
-      subject.extend  committer
+      subject.extend committer
       expect(associated_value).to be_kind_of committer
     end
 
@@ -483,8 +483,8 @@ describe Her::Model::Associations do
     end
 
     it "can use association methods like where" do
-      expect(subject.where(role: 'committer').association.
-        params).to include :role
+      expect(subject.where(role: "committer").association
+        .params).to include :role
     end
   end
 
@@ -510,8 +510,8 @@ describe Her::Model::Associations do
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/10") { |env| [200, {}, { id: 10 }.to_json] }
-            stub.post("/comments") { |env| [200, {}, { id: 1, body: Faraday::Utils.parse_query(env[:body])['body'], user_id: Faraday::Utils.parse_query(env[:body])['user_id'].to_i }.to_json] }
+            stub.get("/users/10") { |_env| [200, {}, { id: 10 }.to_json] }
+            stub.post("/comments") { |env| [200, {}, { id: 1, body: Faraday::Utils.parse_query(env[:body])["body"], user_id: Faraday::Utils.parse_query(env[:body])["user_id"].to_i }.to_json] }
           end
         end
 
@@ -531,14 +531,14 @@ describe Her::Model::Associations do
 
     context "with #new" do
       it "creates nested models from hash attibutes" do
-        user = Foo::User.new(name: "vic", comments: [{text: "hello"}])
+        user = Foo::User.new(name: "vic", comments: [{ text: "hello" }])
         expect(user.comments.first.text).to eq("hello")
       end
 
       it "assigns nested models if given as already constructed objects" do
         bye = Foo::Comment.new(text: "goodbye")
-        user = Foo::User.new(name: 'vic', comments: [bye])
-        expect(user.comments.first.text).to eq('goodbye')
+        user = Foo::User.new(name: "vic", comments: [bye])
+        expect(user.comments.first.text).to eq("goodbye")
       end
     end
   end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -11,7 +11,7 @@ describe Her::Model::Associations do
 
       describe '[:has_many]' do
         subject { super()[:has_many] }
-        it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }] }
+        it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }] }
       end
     end
 
@@ -23,7 +23,7 @@ describe Her::Model::Associations do
 
       describe '[:has_many]' do
         subject { super()[:has_many] }
-        it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }, { :name => :posts, :data_key => :posts, :default => [], :class_name => "Post", :path => "/posts", :inverse_of => nil }] }
+        it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }, { name: :posts, data_key: :posts, default: [], class_name: "Post", path: "/posts", inverse_of: nil }] }
       end
     end
 
@@ -32,7 +32,7 @@ describe Her::Model::Associations do
 
       describe '[:has_one]' do
         subject { super()[:has_one] }
-        it { is_expected.to eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }] }
+        it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }] }
       end
     end
 
@@ -44,7 +44,7 @@ describe Her::Model::Associations do
 
       describe '[:has_one]' do
         subject { super()[:has_one] }
-        it { is_expected.to eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }, { :name => :role, :data_key => :role, :default => nil, :class_name => "Role", :path => "/role" }] }
+        it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }, { name: :role, data_key: :role, default: nil, class_name: "Role", path: "/role" }] }
       end
     end
 
@@ -53,7 +53,7 @@ describe Her::Model::Associations do
 
       describe '[:belongs_to]' do
         subject { super()[:belongs_to] }
-        it { is_expected.to eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }] }
+        it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }] }
       end
     end
 
@@ -65,7 +65,7 @@ describe Her::Model::Associations do
 
       describe '[:belongs_to]' do
         subject { super()[:belongs_to] }
-        it { is_expected.to eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }, { :name => :family, :data_key => :family, :default => nil, :class_name => "Family", :foreign_key => "family_id", :path => "/families/:id" }] }
+        it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }, { name: :family, data_key: :family, default: nil, class_name: "Family", foreign_key: "family_id", path: "/families/:id" }] }
       end
     end
   end
@@ -76,35 +76,35 @@ describe Her::Model::Associations do
 
     context "in base class" do
       context "single has_many association" do
-        before { Foo::User.has_many :comments, :class_name => "Post", :inverse_of => :admin, :data_key => :user_comments, :default => {} }
+        before { Foo::User.has_many :comments, class_name: "Post", inverse_of: :admin, data_key: :user_comments, default: {} }
 
         describe '[:has_many]' do
           subject { super()[:has_many] }
-          it { is_expected.to eql [{ :name => :comments, :data_key => :user_comments, :default => {}, :class_name => "Post", :path => "/comments", :inverse_of => :admin }] }
+          it { is_expected.to eql [{ name: :comments, data_key: :user_comments, default: {}, class_name: "Post", path: "/comments", inverse_of: :admin }] }
         end
       end
 
       context "single has_one association" do
-        before { Foo::User.has_one :category, :class_name => "Topic", :foreign_key => "topic_id", :data_key => :topic, :default => nil }
+        before { Foo::User.has_one :category, class_name: "Topic", foreign_key: "topic_id", data_key: :topic, default: nil }
 
         describe '[:has_one]' do
           subject { super()[:has_one] }
-          it { is_expected.to eql [{ :name => :category, :data_key => :topic, :default => nil, :class_name => "Topic", :foreign_key => "topic_id", :path => "/category" }] }
+          it { is_expected.to eql [{ name: :category, data_key: :topic, default: nil, class_name: "Topic", foreign_key: "topic_id", path: "/category" }] }
         end
       end
 
       context "single belongs_to association" do
-        before { Foo::User.belongs_to :organization, :class_name => "Business", :foreign_key => "org_id", :data_key => :org, :default => true }
+        before { Foo::User.belongs_to :organization, class_name: "Business", foreign_key: "org_id", data_key: :org, default: true }
 
         describe '[:belongs_to]' do
           subject { super()[:belongs_to] }
-          it { is_expected.to eql [{ :name => :organization, :data_key => :org, :default => true, :class_name => "Business", :foreign_key => "org_id", :path => "/organizations/:id" }] }
+          it { is_expected.to eql [{ name: :organization, data_key: :org, default: true, class_name: "Business", foreign_key: "org_id", path: "/organizations/:id" }] }
         end
       end
     end
 
     context "in parent class" do
-      before { Foo::User.has_many :comments, :class_name => "Post" }
+      before { Foo::User.has_many :comments, class_name: "Post" }
 
       describe "associations accessor" do
         subject { Class.new(Foo::User).associations }
@@ -116,7 +116,7 @@ describe Her::Model::Associations do
 
         describe '[:has_many]' do
           subject { super()[:has_many] }
-          it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Post", :path => "/comments", :inverse_of => nil }] }
+          it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Post", path: "/comments", inverse_of: nil }] }
         end
       end
     end
@@ -124,28 +124,28 @@ describe Her::Model::Associations do
 
   context "handling associations without details" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :comments => [{ :comment => { :id => 2, :body => "Tobias, you blow hard!", :user_id => 1 } }, { :comment => { :id => 3, :body => "I wouldn't mind kissing that man between the cheeks, so to speak", :user_id => 1 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 1, :name => "Bluth Company" }, :organization_id => 1 }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 2, :name => "Lindsay Fünke", :organization_id => 2 }.to_json] }
-          stub.get("/users/1/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }].to_json] }
-          stub.get("/users/2/comments") { |env| [200, {}, [{ :comment => { :id => 4, :body => "They're having a FIRESALE?" } }, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?" } }].to_json] }
-          stub.get("/users/2/comments/5") { |env| [200, {}, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/users/2/role") { |env| [200, {}, { :id => 2, :body => "User" }.to_json] }
-          stub.get("/users/1/role") { |env| [200, {}, { :id => 3, :body => "User" }.to_json] }
-          stub.get("/users/1/posts") { |env| [200, {}, [{:id => 1, :body => 'blogging stuff', :admin_id => 1 }].to_json] }
-          stub.get("/organizations/1") { |env| [200, {}, { :organization =>  { :id => 1, :name => "Bluth Company Foo" } }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :id => 5, :name => "Mr. Krabs", :comments => [{ :comment => { :id => 99, :body => "Rodríguez, nasibisibusi?", :user_id => 5 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 3, :name => "Krusty Krab" }, :organization_id => 3 }.to_json] }
-          stub.put("/users/5") { |env| [200, {}, { :id => 5, :name => "Clancy Brown", :comments => [{ :comment => { :id => 99, :body => "Rodríguez, nasibisibusi?", :user_id => 5 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 3, :name => "Krusty Krab" }, :organization_id => 3 }.to_json] }
-          stub.delete("/users/5") { |env| [200, {}, { :id => 5, :name => "Clancy Brown", :comments => [{ :comment => { :id => 99, :body => "Rodríguez, nasibisibusi?", :user_id => 5 } }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 3, :name => "Krusty Krab" }, :organization_id => 3 }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke", comments: [{ comment: { id: 2, body: "Tobias, you blow hard!", user_id: 1 } }, { comment: { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 } }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("/users/1/comments") { |env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }].to_json] }
+          stub.get("/users/2/comments") { |env| [200, {}, [{ comment: { id: 4, body: "They're having a FIRESALE?" } }, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }].to_json] }
+          stub.get("/users/2/comments/5") { |env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/users/2/role") { |env| [200, {}, { id: 2, body: "User" }.to_json] }
+          stub.get("/users/1/role") { |env| [200, {}, { id: 3, body: "User" }.to_json] }
+          stub.get("/users/1/posts") { |env| [200, {}, [{id: 1, body: 'blogging stuff', admin_id: 1 }].to_json] }
+          stub.get("/organizations/1") { |env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
+          stub.post("/users") { |env| [200, {}, { id: 5, name: "Mr. Krabs", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.put("/users/5") { |env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
+          stub.delete("/users/5") { |env| [200, {}, { id: 5, name: "Clancy Brown", comments: [{ comment: { id: 99, body: "Rodríguez, nasibisibusi?", user_id: 5 } }], role: { id: 1, body: "Admin" }, organization: { id: 3, name: "Krusty Krab" }, organization_id: 3 }.to_json] }
 
           stub.get("/organizations/2") do |env|
             if env[:params]["admin"] == "true"
-              [200, {}, { :organization => { :id => 2, :name => "Bluth Company (admin)" } }.to_json]
+              [200, {}, { organization: { id: 2, name: "Bluth Company (admin)" } }.to_json]
             else
-              [200, {}, { :organization => { :id => 2, :name => "Bluth Company" } }.to_json]
+              [200, {}, { organization: { id: 2, name: "Bluth Company" } }.to_json]
             end
           end
         end
@@ -155,14 +155,14 @@ describe Her::Model::Associations do
         has_many :comments, class_name: "Foo::Comment"
         has_one :role
         belongs_to :organization
-        has_many :posts, :inverse_of => :admin
+        has_many :posts, inverse_of: :admin
       end
       spawn_model "Foo::Comment" do
         belongs_to :user
         parse_root_in_json true
       end
       spawn_model "Foo::Post" do
-        belongs_to :admin, :class_name => 'Foo::User'
+        belongs_to :admin, class_name: 'Foo::User'
       end
 
       spawn_model "Foo::Organization" do
@@ -177,9 +177,9 @@ describe Her::Model::Associations do
     end
 
     let(:user_with_included_data_after_create) { Foo::User.create }
-    let(:user_with_included_data_after_save_existing) { Foo::User.save_existing(5, :name => "Clancy Brown") }
-    let(:user_with_included_data_after_destroy) { Foo::User.new(:id => 5).destroy }
-    let(:comment_without_included_parent_data) { Foo::Comment.new(:id => 7, :user_id => 1) }
+    let(:user_with_included_data_after_save_existing) { Foo::User.save_existing(5, name: "Clancy Brown") }
+    let(:user_with_included_data_after_destroy) { Foo::User.new(id: 5).destroy }
+    let(:comment_without_included_parent_data) { Foo::Comment.new(id: 7, user_id: 1) }
 
     it "maps an array of included data through has_many" do
       expect(@user_with_included_data.comments.first).to be_a(Foo::Comment)
@@ -197,7 +197,7 @@ describe Her::Model::Associations do
     end
 
     it "does fetch the parent models data that was cached if called with parameters" do
-      expect(comment_without_included_parent_data.user.object_id).not_to eq(comment_without_included_parent_data.user.where(:a => 2).object_id)
+      expect(comment_without_included_parent_data.user.object_id).not_to eq(comment_without_included_parent_data.user.where(a: 2).object_id)
     end
 
     it "uses the given inverse_of key to set the parent model" do
@@ -212,7 +212,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches has_many data even if it was included, only if called with parameters" do
-      expect(@user_with_included_data.comments.where(:foo_id => 1).length).to eq(1)
+      expect(@user_with_included_data.comments.where(foo_id: 1).length).to eq(1)
     end
 
     it "fetches data that was not included through has_many only once" do
@@ -220,7 +220,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches data that was cached through has_many if called with parameters" do
-      expect(@user_without_included_data.comments.first.object_id).not_to eq(@user_without_included_data.comments.where(:foo_id => 1).first.object_id)
+      expect(@user_without_included_data.comments.first.object_id).not_to eq(@user_without_included_data.comments.where(foo_id: 1).first.object_id)
     end
 
     it "maps an array of included data through has_one" do
@@ -237,7 +237,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches has_one data even if it was included, only if called with parameters" do
-      expect(@user_with_included_data.role.where(:foo_id => 2).id).to eq(3)
+      expect(@user_with_included_data.role.where(foo_id: 2).id).to eq(3)
     end
 
     it "maps an array of included data through belongs_to" do
@@ -257,7 +257,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches belongs_to data even if it was included, only if called with parameters" do
-      expect(@user_with_included_data.organization.where(:foo_id => 1).name).to eq("Bluth Company Foo")
+      expect(@user_with_included_data.organization.where(foo_id: 1).name).to eq("Bluth Company Foo")
     end
 
     it "can tell if it has a association" do
@@ -271,7 +271,7 @@ describe Her::Model::Associations do
     end
 
     it "pass query string parameters when additional arguments are passed" do
-      expect(@user_without_included_data.organization.where(:admin => true).name).to eq("Bluth Company (admin)")
+      expect(@user_without_included_data.organization.where(admin: true).name).to eq("Bluth Company (admin)")
       expect(@user_without_included_data.organization.name).to eq("Bluth Company")
     end
 
@@ -314,29 +314,29 @@ describe Her::Model::Associations do
 
   context "handling associations with details in active_model_serializers format" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :user => { :id => 1, :name => "Tobias Fünke", :comments => [{ :id => 2, :body => "Tobias, you blow hard!", :user_id => 1 }, { :id => 3, :body => "I wouldn't mind kissing that man between the cheeks, so to speak", :user_id => 1 }], :role => { :id => 1, :body => "Admin" }, :organization => { :id => 1, :name => "Bluth Company" }, :organization_id => 1 } }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :user => { :id => 2, :name => "Lindsay Fünke", :organization_id => 1 } }.to_json] }
-          stub.get("/users/1/comments") { |env| [200, {}, { :comments => [{ :id => 4, :body => "They're having a FIRESALE?" }] }.to_json] }
-          stub.get("/users/2/comments") { |env| [200, {}, { :comments => [{ :id => 4, :body => "They're having a FIRESALE?" }, { :id => 5, :body => "Is this the tiny town from Footloose?" }] }.to_json] }
-          stub.get("/users/2/comments/5") { |env| [200, {}, { :comment => { :id => 5, :body => "Is this the tiny town from Footloose?" } }.to_json] }
-          stub.get("/organizations/1") { |env| [200, {}, { :organization =>  { :id => 1, :name => "Bluth Company Foo" } }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, name: "Tobias Fünke", comments: [{ id: 2, body: "Tobias, you blow hard!", user_id: 1 }, { id: 3, body: "I wouldn't mind kissing that man between the cheeks, so to speak", user_id: 1 }], role: { id: 1, body: "Admin" }, organization: { id: 1, name: "Bluth Company" }, organization_id: 1 } }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { user: { id: 2, name: "Lindsay Fünke", organization_id: 1 } }.to_json] }
+          stub.get("/users/1/comments") { |env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }] }.to_json] }
+          stub.get("/users/2/comments") { |env| [200, {}, { comments: [{ id: 4, body: "They're having a FIRESALE?" }, { id: 5, body: "Is this the tiny town from Footloose?" }] }.to_json] }
+          stub.get("/users/2/comments/5") { |env| [200, {}, { comment: { id: 5, body: "Is this the tiny town from Footloose?" } }.to_json] }
+          stub.get("/organizations/1") { |env| [200, {}, { organization:  { id: 1, name: "Bluth Company Foo" } }.to_json] }
         end
       end
       spawn_model "Foo::User" do
-        parse_root_in_json true, :format => :active_model_serializers
+        parse_root_in_json true, format: :active_model_serializers
         has_many :comments, class_name: "Foo::Comment"
         belongs_to :organization
       end
       spawn_model "Foo::Comment" do
         belongs_to :user
-        parse_root_in_json true, :format => :active_model_serializers
+        parse_root_in_json true, format: :active_model_serializers
       end
       spawn_model "Foo::Organization" do
-        parse_root_in_json true, :format => :active_model_serializers
+        parse_root_in_json true, format: :active_model_serializers
       end
 
       @user_with_included_data = Foo::User.find(1)
@@ -362,7 +362,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches has_many data even if it was included, only if called with parameters" do
-      expect(@user_with_included_data.comments.where(:foo_id => 1).length).to eq(1)
+      expect(@user_with_included_data.comments.where(foo_id: 1).length).to eq(1)
     end
 
     it "maps an array of included data through belongs_to" do
@@ -378,7 +378,7 @@ describe Her::Model::Associations do
     end
 
     it "fetches belongs_to data even if it was included, only if called with parameters" do
-      expect(@user_with_included_data.organization.where(:foo_id => 1).name).to eq("Bluth Company Foo")
+      expect(@user_with_included_data.organization.where(foo_id: 1).name).to eq("Bluth Company Foo")
     end
 
     it "fetches data with the specified id when calling find" do
@@ -396,20 +396,20 @@ describe Her::Model::Associations do
 
   context "handling associations with details" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :organization => { :id => 1, :name => "Bluth Company Inc." }, :organization_id => 1 }.to_json] }
-          stub.get("/users/4") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke", :organization => { :id => 1, :name => "Bluth Company Inc." } }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 2, :name => "Lindsay Fünke", :organization_id => 1 }.to_json] }
-          stub.get("/users/3") { |env| [200, {}, { :id => 2, :name => "Lindsay Fünke", :company => nil }.to_json] }
-          stub.get("/companies/1") { |env| [200, {}, { :id => 1, :name => "Bluth Company" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
+          stub.get("/users/4") { |env| [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
+          stub.get("/users/3") { |env| [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
+          stub.get("/companies/1") { |env| [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
         end
       end
 
       spawn_model "Foo::User" do
-        belongs_to :company, :path => "/organizations/:id", :foreign_key => :organization_id, :data_key => :organization
+        belongs_to :company, path: "/organizations/:id", foreign_key: :organization_id, data_key: :organization
       end
 
       spawn_model "Foo::Company"
@@ -498,7 +498,7 @@ describe Her::Model::Associations do
 
     context "with #build" do
       it "takes the parent primary key" do
-        @comment = Foo::User.new(:id => 10).comments.build(:body => "Hello!")
+        @comment = Foo::User.new(id: 10).comments.build(body: "Hello!")
         expect(@comment.body).to eq("Hello!")
         expect(@comment.user_id).to eq(10)
       end
@@ -506,12 +506,12 @@ describe Her::Model::Associations do
 
     context "with #create" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/10") { |env| [200, {}, { :id => 10 }.to_json] }
-            stub.post("/comments") { |env| [200, {}, { :id => 1, :body => Faraday::Utils.parse_query(env[:body])['body'], :user_id => Faraday::Utils.parse_query(env[:body])['user_id'].to_i }.to_json] }
+            stub.get("/users/10") { |env| [200, {}, { id: 10 }.to_json] }
+            stub.post("/comments") { |env| [200, {}, { id: 1, body: Faraday::Utils.parse_query(env[:body])['body'], user_id: Faraday::Utils.parse_query(env[:body])['user_id'].to_i }.to_json] }
           end
         end
 
@@ -521,7 +521,7 @@ describe Her::Model::Associations do
 
       it "takes the parent primary key and saves the resource" do
         @user = Foo::User.find(10)
-        @comment = @user.comments.create(:body => "Hello!")
+        @comment = @user.comments.create(body: "Hello!")
         expect(@comment.id).to eq(1)
         expect(@comment.body).to eq("Hello!")
         expect(@comment.user_id).to eq(10)
@@ -531,13 +531,13 @@ describe Her::Model::Associations do
 
     context "with #new" do
       it "creates nested models from hash attibutes" do
-        user = Foo::User.new(:name => "vic", :comments => [{:text => "hello"}])
+        user = Foo::User.new(name: "vic", comments: [{text: "hello"}])
         expect(user.comments.first.text).to eq("hello")
       end
 
       it "assigns nested models if given as already constructed objects" do
-        bye = Foo::Comment.new(:text => "goodbye")
-        user = Foo::User.new(:name => 'vic', :comments => [bye])
+        bye = Foo::Comment.new(text: "goodbye")
+        user = Foo::User.new(name: 'vic', comments: [bye])
         expect(user.comments.first.text).to eq('goodbye')
       end
     end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -8,7 +8,11 @@ describe Her::Model::Associations do
 
     context "single has_many association" do
       before { Foo::User.has_many :comments }
-      its([:has_many]) { should eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }] }
+
+      describe '[:has_many]' do
+        subject { super()[:has_many] }
+        it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }] }
+      end
     end
 
     context "multiple has_many associations" do
@@ -17,12 +21,19 @@ describe Her::Model::Associations do
         Foo::User.has_many :posts
       end
 
-      its([:has_many]) { should eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }, { :name => :posts, :data_key => :posts, :default => [], :class_name => "Post", :path => "/posts", :inverse_of => nil }] }
+      describe '[:has_many]' do
+        subject { super()[:has_many] }
+        it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Comment", :path => "/comments", :inverse_of => nil }, { :name => :posts, :data_key => :posts, :default => [], :class_name => "Post", :path => "/posts", :inverse_of => nil }] }
+      end
     end
 
     context "single has_one association" do
       before { Foo::User.has_one :category }
-      its([:has_one]) { should eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }] }
+
+      describe '[:has_one]' do
+        subject { super()[:has_one] }
+        it { is_expected.to eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }] }
+      end
     end
 
     context "multiple has_one associations" do
@@ -31,12 +42,19 @@ describe Her::Model::Associations do
         Foo::User.has_one :role
       end
 
-      its([:has_one]) { should eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }, { :name => :role, :data_key => :role, :default => nil, :class_name => "Role", :path => "/role" }] }
+      describe '[:has_one]' do
+        subject { super()[:has_one] }
+        it { is_expected.to eql [{ :name => :category, :data_key => :category, :default => nil, :class_name => "Category", :path => "/category" }, { :name => :role, :data_key => :role, :default => nil, :class_name => "Role", :path => "/role" }] }
+      end
     end
 
     context "single belongs_to association" do
       before { Foo::User.belongs_to :organization }
-      its([:belongs_to]) { should eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }] }
+
+      describe '[:belongs_to]' do
+        subject { super()[:belongs_to] }
+        it { is_expected.to eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }] }
+      end
     end
 
     context "multiple belongs_to association" do
@@ -45,7 +63,10 @@ describe Her::Model::Associations do
         Foo::User.belongs_to :family
       end
 
-      its([:belongs_to]) { should eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }, { :name => :family, :data_key => :family, :default => nil, :class_name => "Family", :foreign_key => "family_id", :path => "/families/:id" }] }
+      describe '[:belongs_to]' do
+        subject { super()[:belongs_to] }
+        it { is_expected.to eql [{ :name => :organization, :data_key => :organization, :default => nil, :class_name => "Organization", :foreign_key => "organization_id", :path => "/organizations/:id" }, { :name => :family, :data_key => :family, :default => nil, :class_name => "Family", :foreign_key => "family_id", :path => "/families/:id" }] }
+      end
     end
   end
 
@@ -56,17 +77,29 @@ describe Her::Model::Associations do
     context "in base class" do
       context "single has_many association" do
         before { Foo::User.has_many :comments, :class_name => "Post", :inverse_of => :admin, :data_key => :user_comments, :default => {} }
-        its([:has_many]) { should eql [{ :name => :comments, :data_key => :user_comments, :default => {}, :class_name => "Post", :path => "/comments", :inverse_of => :admin }] }
+
+        describe '[:has_many]' do
+          subject { super()[:has_many] }
+          it { is_expected.to eql [{ :name => :comments, :data_key => :user_comments, :default => {}, :class_name => "Post", :path => "/comments", :inverse_of => :admin }] }
+        end
       end
 
       context "single has_one association" do
         before { Foo::User.has_one :category, :class_name => "Topic", :foreign_key => "topic_id", :data_key => :topic, :default => nil }
-        its([:has_one]) { should eql [{ :name => :category, :data_key => :topic, :default => nil, :class_name => "Topic", :foreign_key => "topic_id", :path => "/category" }] }
+
+        describe '[:has_one]' do
+          subject { super()[:has_one] }
+          it { is_expected.to eql [{ :name => :category, :data_key => :topic, :default => nil, :class_name => "Topic", :foreign_key => "topic_id", :path => "/category" }] }
+        end
       end
 
       context "single belongs_to association" do
         before { Foo::User.belongs_to :organization, :class_name => "Business", :foreign_key => "org_id", :data_key => :org, :default => true }
-        its([:belongs_to]) { should eql [{ :name => :organization, :data_key => :org, :default => true, :class_name => "Business", :foreign_key => "org_id", :path => "/organizations/:id" }] }
+
+        describe '[:belongs_to]' do
+          subject { super()[:belongs_to] }
+          it { is_expected.to eql [{ :name => :organization, :data_key => :org, :default => true, :class_name => "Business", :foreign_key => "org_id", :path => "/organizations/:id" }] }
+        end
       end
     end
 
@@ -75,8 +108,16 @@ describe Her::Model::Associations do
 
       describe "associations accessor" do
         subject { Class.new(Foo::User).associations }
-        its(:object_id) { should_not eql Foo::User.associations.object_id }
-        its([:has_many]) { should eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Post", :path => "/comments", :inverse_of => nil }] }
+
+        describe '#object_id' do
+          subject { super().object_id }
+          it { is_expected.not_to eql Foo::User.associations.object_id }
+        end
+
+        describe '[:has_many]' do
+          subject { super()[:has_many] }
+          it { is_expected.to eql [{ :name => :comments, :data_key => :comments, :default => [], :class_name => "Post", :path => "/comments", :inverse_of => nil }] }
+        end
       end
     end
   end
@@ -141,114 +182,114 @@ describe Her::Model::Associations do
     let(:comment_without_included_parent_data) { Foo::Comment.new(:id => 7, :user_id => 1) }
 
     it "maps an array of included data through has_many" do
-      @user_with_included_data.comments.first.should be_a(Foo::Comment)
-      @user_with_included_data.comments.length.should == 2
-      @user_with_included_data.comments.first.id.should == 2
-      @user_with_included_data.comments.first.body.should == "Tobias, you blow hard!"
+      expect(@user_with_included_data.comments.first).to be_a(Foo::Comment)
+      expect(@user_with_included_data.comments.length).to eq(2)
+      expect(@user_with_included_data.comments.first.id).to eq(2)
+      expect(@user_with_included_data.comments.first.body).to eq("Tobias, you blow hard!")
     end
 
     it "does not refetch the parents models data if they have been fetched before" do
-      @user_with_included_data.comments.first.user.object_id.should == @user_with_included_data.object_id
+      expect(@user_with_included_data.comments.first.user.object_id).to eq(@user_with_included_data.object_id)
     end
 
     it "does fetch the parent models data only once" do
-      comment_without_included_parent_data.user.object_id.should == comment_without_included_parent_data.user.object_id
+      expect(comment_without_included_parent_data.user.object_id).to eq(comment_without_included_parent_data.user.object_id)
     end
 
     it "does fetch the parent models data that was cached if called with parameters" do
-      comment_without_included_parent_data.user.object_id.should_not == comment_without_included_parent_data.user.where(:a => 2).object_id
+      expect(comment_without_included_parent_data.user.object_id).not_to eq(comment_without_included_parent_data.user.where(:a => 2).object_id)
     end
 
     it "uses the given inverse_of key to set the parent model" do
-      @user_with_included_data.posts.first.admin.object_id.should == @user_with_included_data.object_id
+      expect(@user_with_included_data.posts.first.admin.object_id).to eq(@user_with_included_data.object_id)
     end
 
     it "fetches data that was not included through has_many" do
-      @user_without_included_data.comments.first.should be_a(Foo::Comment)
-      @user_without_included_data.comments.length.should == 2
-      @user_without_included_data.comments.first.id.should == 4
-      @user_without_included_data.comments.first.body.should == "They're having a FIRESALE?"
+      expect(@user_without_included_data.comments.first).to be_a(Foo::Comment)
+      expect(@user_without_included_data.comments.length).to eq(2)
+      expect(@user_without_included_data.comments.first.id).to eq(4)
+      expect(@user_without_included_data.comments.first.body).to eq("They're having a FIRESALE?")
     end
 
     it "fetches has_many data even if it was included, only if called with parameters" do
-      @user_with_included_data.comments.where(:foo_id => 1).length.should == 1
+      expect(@user_with_included_data.comments.where(:foo_id => 1).length).to eq(1)
     end
 
     it "fetches data that was not included through has_many only once" do
-      @user_without_included_data.comments.first.object_id.should == @user_without_included_data.comments.first.object_id
+      expect(@user_without_included_data.comments.first.object_id).to eq(@user_without_included_data.comments.first.object_id)
     end
 
     it "fetches data that was cached through has_many if called with parameters" do
-      @user_without_included_data.comments.first.object_id.should_not == @user_without_included_data.comments.where(:foo_id => 1).first.object_id
+      expect(@user_without_included_data.comments.first.object_id).not_to eq(@user_without_included_data.comments.where(:foo_id => 1).first.object_id)
     end
 
     it "maps an array of included data through has_one" do
-      @user_with_included_data.role.should be_a(Foo::Role)
-      @user_with_included_data.role.object_id.should == @user_with_included_data.role.object_id
-      @user_with_included_data.role.id.should == 1
-      @user_with_included_data.role.body.should == "Admin"
+      expect(@user_with_included_data.role).to be_a(Foo::Role)
+      expect(@user_with_included_data.role.object_id).to eq(@user_with_included_data.role.object_id)
+      expect(@user_with_included_data.role.id).to eq(1)
+      expect(@user_with_included_data.role.body).to eq("Admin")
     end
 
     it "fetches data that was not included through has_one" do
-      @user_without_included_data.role.should be_a(Foo::Role)
-      @user_without_included_data.role.id.should == 2
-      @user_without_included_data.role.body.should == "User"
+      expect(@user_without_included_data.role).to be_a(Foo::Role)
+      expect(@user_without_included_data.role.id).to eq(2)
+      expect(@user_without_included_data.role.body).to eq("User")
     end
 
     it "fetches has_one data even if it was included, only if called with parameters" do
-      @user_with_included_data.role.where(:foo_id => 2).id.should == 3
+      expect(@user_with_included_data.role.where(:foo_id => 2).id).to eq(3)
     end
 
     it "maps an array of included data through belongs_to" do
-      @user_with_included_data.organization.should be_a(Foo::Organization)
-      @user_with_included_data.organization.id.should == 1
-      @user_with_included_data.organization.name.should == "Bluth Company"
+      expect(@user_with_included_data.organization).to be_a(Foo::Organization)
+      expect(@user_with_included_data.organization.id).to eq(1)
+      expect(@user_with_included_data.organization.name).to eq("Bluth Company")
     end
 
     it "fetches data that was not included through belongs_to" do
-      @user_without_included_data.organization.should be_a(Foo::Organization)
-      @user_without_included_data.organization.id.should == 2
-      @user_without_included_data.organization.name.should == "Bluth Company"
+      expect(@user_without_included_data.organization).to be_a(Foo::Organization)
+      expect(@user_without_included_data.organization.id).to eq(2)
+      expect(@user_without_included_data.organization.name).to eq("Bluth Company")
     end
 
     it "returns nil if the foreign key is nil" do
-      @user_without_organization_and_not_persisted.organization.should be_nil
+      expect(@user_without_organization_and_not_persisted.organization).to be_nil
     end
 
     it "fetches belongs_to data even if it was included, only if called with parameters" do
-      @user_with_included_data.organization.where(:foo_id => 1).name.should == "Bluth Company Foo"
+      expect(@user_with_included_data.organization.where(:foo_id => 1).name).to eq("Bluth Company Foo")
     end
 
     it "can tell if it has a association" do
-      @user_without_included_data.has_association?(:unknown_association).should be false
-      @user_without_included_data.has_association?(:organization).should be true
+      expect(@user_without_included_data.has_association?(:unknown_association)).to be false
+      expect(@user_without_included_data.has_association?(:organization)).to be true
     end
 
     it "fetches the resource corresponding to a named association" do
-      @user_without_included_data.get_association(:unknown_association).should be_nil
-      @user_without_included_data.get_association(:organization).name.should == "Bluth Company"
+      expect(@user_without_included_data.get_association(:unknown_association)).to be_nil
+      expect(@user_without_included_data.get_association(:organization).name).to eq("Bluth Company")
     end
 
     it "pass query string parameters when additional arguments are passed" do
-      @user_without_included_data.organization.where(:admin => true).name.should == "Bluth Company (admin)"
-      @user_without_included_data.organization.name.should == "Bluth Company"
+      expect(@user_without_included_data.organization.where(:admin => true).name).to eq("Bluth Company (admin)")
+      expect(@user_without_included_data.organization.name).to eq("Bluth Company")
     end
 
     it "fetches data with the specified id when calling find" do
       comment = @user_without_included_data.comments.find(5)
-      comment.should be_a(Foo::Comment)
-      comment.id.should eq(5)
+      expect(comment).to be_a(Foo::Comment)
+      expect(comment.id).to eq(5)
     end
 
     it "'s associations responds to #empty?" do
-      @user_without_included_data.organization.respond_to?(:empty?).should be_truthy
-      @user_without_included_data.organization.should_not be_empty
+      expect(@user_without_included_data.organization.respond_to?(:empty?)).to be_truthy
+      expect(@user_without_included_data.organization).not_to be_empty
     end
 
     it 'includes has_many relationships in params by default' do
       params = @user_with_included_data.to_params
-      params[:comments].should be_kind_of(Array)
-      params[:comments].length.should eq(2)
+      expect(params[:comments]).to be_kind_of(Array)
+      expect(params[:comments].length).to eq(2)
     end
 
     [:create, :save_existing, :destroy].each do |type|
@@ -256,16 +297,16 @@ describe Her::Model::Associations do
         let(:subject) { self.send("user_with_included_data_after_#{type}")}
 
         it "maps an array of included data through has_many" do
-          subject.comments.first.should be_a(Foo::Comment)
-          subject.comments.length.should == 1
-          subject.comments.first.id.should == 99
-          subject.comments.first.body.should == "Rodríguez, nasibisibusi?"
+          expect(subject.comments.first).to be_a(Foo::Comment)
+          expect(subject.comments.length).to eq(1)
+          expect(subject.comments.first.id).to eq(99)
+          expect(subject.comments.first.body).to eq("Rodríguez, nasibisibusi?")
         end
 
         it "maps an array of included data through has_one" do
-          subject.role.should be_a(Foo::Role)
-          subject.role.id.should == 1
-          subject.role.body.should == "Admin"
+          expect(subject.role).to be_a(Foo::Role)
+          expect(subject.role.id).to eq(1)
+          expect(subject.role.body).to eq("Admin")
         end
       end
     end
@@ -303,53 +344,53 @@ describe Her::Model::Associations do
     end
 
     it "maps an array of included data through has_many" do
-      @user_with_included_data.comments.first.should be_a(Foo::Comment)
-      @user_with_included_data.comments.length.should == 2
-      @user_with_included_data.comments.first.id.should == 2
-      @user_with_included_data.comments.first.body.should == "Tobias, you blow hard!"
+      expect(@user_with_included_data.comments.first).to be_a(Foo::Comment)
+      expect(@user_with_included_data.comments.length).to eq(2)
+      expect(@user_with_included_data.comments.first.id).to eq(2)
+      expect(@user_with_included_data.comments.first.body).to eq("Tobias, you blow hard!")
     end
 
     it "does not refetch the parents models data if they have been fetched before" do
-      @user_with_included_data.comments.first.user.object_id.should == @user_with_included_data.object_id
+      expect(@user_with_included_data.comments.first.user.object_id).to eq(@user_with_included_data.object_id)
     end
 
     it "fetches data that was not included through has_many" do
-      @user_without_included_data.comments.first.should be_a(Foo::Comment)
-      @user_without_included_data.comments.length.should == 2
-      @user_without_included_data.comments.first.id.should == 4
-      @user_without_included_data.comments.first.body.should == "They're having a FIRESALE?"
+      expect(@user_without_included_data.comments.first).to be_a(Foo::Comment)
+      expect(@user_without_included_data.comments.length).to eq(2)
+      expect(@user_without_included_data.comments.first.id).to eq(4)
+      expect(@user_without_included_data.comments.first.body).to eq("They're having a FIRESALE?")
     end
 
     it "fetches has_many data even if it was included, only if called with parameters" do
-      @user_with_included_data.comments.where(:foo_id => 1).length.should == 1
+      expect(@user_with_included_data.comments.where(:foo_id => 1).length).to eq(1)
     end
 
     it "maps an array of included data through belongs_to" do
-      @user_with_included_data.organization.should be_a(Foo::Organization)
-      @user_with_included_data.organization.id.should == 1
-      @user_with_included_data.organization.name.should == "Bluth Company"
+      expect(@user_with_included_data.organization).to be_a(Foo::Organization)
+      expect(@user_with_included_data.organization.id).to eq(1)
+      expect(@user_with_included_data.organization.name).to eq("Bluth Company")
     end
 
     it "fetches data that was not included through belongs_to" do
-      @user_without_included_data.organization.should be_a(Foo::Organization)
-      @user_without_included_data.organization.id.should == 1
-      @user_without_included_data.organization.name.should == "Bluth Company Foo"
+      expect(@user_without_included_data.organization).to be_a(Foo::Organization)
+      expect(@user_without_included_data.organization.id).to eq(1)
+      expect(@user_without_included_data.organization.name).to eq("Bluth Company Foo")
     end
 
     it "fetches belongs_to data even if it was included, only if called with parameters" do
-      @user_with_included_data.organization.where(:foo_id => 1).name.should == "Bluth Company Foo"
+      expect(@user_with_included_data.organization.where(:foo_id => 1).name).to eq("Bluth Company Foo")
     end
 
     it "fetches data with the specified id when calling find" do
       comment = @user_without_included_data.comments.find(5)
-      comment.should be_a(Foo::Comment)
-      comment.id.should eq(5)
+      expect(comment).to be_a(Foo::Comment)
+      expect(comment.id).to eq(5)
     end
 
     it 'includes has_many relationships in params by default' do
       params = @user_with_included_data.to_params
-      params[:comments].should be_kind_of(Array)
-      params[:comments].length.should eq(2)
+      expect(params[:comments]).to be_kind_of(Array)
+      expect(params[:comments].length).to eq(2)
     end
   end
 
@@ -380,23 +421,23 @@ describe Her::Model::Associations do
     end
 
     it "maps an array of included data through belongs_to" do
-      @user_with_included_data.company.should be_a(Foo::Company)
-      @user_with_included_data.company.id.should == 1
-      @user_with_included_data.company.name.should == "Bluth Company Inc."
+      expect(@user_with_included_data.company).to be_a(Foo::Company)
+      expect(@user_with_included_data.company.id).to eq(1)
+      expect(@user_with_included_data.company.name).to eq("Bluth Company Inc.")
     end
 
     it "does not map included data if it’s nil" do
-      @user_with_included_nil_data.company.should be_nil
+      expect(@user_with_included_nil_data.company).to be_nil
     end
 
     it "fetches data that was not included through belongs_to" do
-      @user_without_included_data.company.should be_a(Foo::Company)
-      @user_without_included_data.company.id.should == 1
-      @user_without_included_data.company.name.should == "Bluth Company"
+      expect(@user_without_included_data.company).to be_a(Foo::Company)
+      expect(@user_without_included_data.company.id).to eq(1)
+      expect(@user_without_included_data.company.name).to eq("Bluth Company")
     end
 
     it "does not require foreugn key to have nested object" do
-      @user_with_included_data_but_no_fk.company.name.should == "Bluth Company Inc."
+      expect(@user_with_included_data_but_no_fk.company.name).to eq("Bluth Company Inc.")
     end
   end
 
@@ -420,30 +461,30 @@ describe Her::Model::Associations do
     subject { user_with_role.role }
 
     it "doesnt mask the object's basic methods" do
-      subject.class.should == Foo::Role
+      expect(subject.class).to eq(Foo::Role)
     end
 
     it "doesnt mask core methods like extend" do
       committer = Module.new
       subject.extend  committer
-      associated_value.should be_kind_of committer
+      expect(associated_value).to be_kind_of committer
     end
 
     it "can return the association object" do
-      subject.association.should be_kind_of Her::Model::Associations::Association
+      expect(subject.association).to be_kind_of Her::Model::Associations::Association
     end
 
     it "still can call fetch via the association" do
-      subject.association.fetch.should eq associated_value
+      expect(subject.association.fetch).to eq associated_value
     end
 
     it "calls missing methods on associated value" do
-      subject.present?.should == "of_course"
+      expect(subject.present?).to eq("of_course")
     end
 
     it "can use association methods like where" do
-      subject.where(role: 'committer').association.
-        params.should include :role
+      expect(subject.where(role: 'committer').association.
+        params).to include :role
     end
   end
 
@@ -458,8 +499,8 @@ describe Her::Model::Associations do
     context "with #build" do
       it "takes the parent primary key" do
         @comment = Foo::User.new(:id => 10).comments.build(:body => "Hello!")
-        @comment.body.should == "Hello!"
-        @comment.user_id.should == 10
+        expect(@comment.body).to eq("Hello!")
+        expect(@comment.user_id).to eq(10)
       end
     end
 
@@ -481,23 +522,23 @@ describe Her::Model::Associations do
       it "takes the parent primary key and saves the resource" do
         @user = Foo::User.find(10)
         @comment = @user.comments.create(:body => "Hello!")
-        @comment.id.should == 1
-        @comment.body.should == "Hello!"
-        @comment.user_id.should == 10
-        @user.comments.should == [@comment]
+        expect(@comment.id).to eq(1)
+        expect(@comment.body).to eq("Hello!")
+        expect(@comment.user_id).to eq(10)
+        expect(@user.comments).to eq([@comment])
       end
     end
 
     context "with #new" do
       it "creates nested models from hash attibutes" do
         user = Foo::User.new(:name => "vic", :comments => [{:text => "hello"}])
-        user.comments.first.text.should == "hello"
+        expect(user.comments.first.text).to eq("hello")
       end
 
       it "assigns nested models if given as already constructed objects" do
         bye = Foo::Comment.new(:text => "goodbye")
         user = Foo::User.new(:name => 'vic', :comments => [bye])
-        user.comments.first.text.should == 'goodbye'
+        expect(user.comments.first.text).to eq('goodbye')
       end
     end
   end

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -12,28 +12,28 @@ describe Her::Model::Attributes do
     end
 
     it "accepts new resource with strings as hash keys" do
-      @new_user = Foo::User.new('fullname' => "Tobias Fünke")
+      @new_user = Foo::User.new("fullname" => "Tobias Fünke")
       expect(@new_user.fullname).to eq("Tobias Fünke")
     end
 
     it "handles method missing for getter" do
-      @new_user = Foo::User.new(fullname: 'Mayonegg')
+      @new_user = Foo::User.new(fullname: "Mayonegg")
       expect { @new_user.unknown_method_for_a_user }.to raise_error(NoMethodError)
-      expect { @new_user.fullname }.not_to raise_error()
+      expect { @new_user.fullname }.not_to raise_error
     end
 
     it "handles method missing for setter" do
       @new_user = Foo::User.new
-      expect { @new_user.fullname = "Tobias Fünke" }.not_to raise_error()
+      expect { @new_user.fullname = "Tobias Fünke" }.not_to raise_error
     end
 
     it "handles method missing for query" do
       @new_user = Foo::User.new
-      expect { @new_user.fullname? }.not_to raise_error()
+      expect { @new_user.fullname? }.not_to raise_error
     end
 
     it "handles respond_to for getter" do
-      @new_user = Foo::User.new(fullname: 'Mayonegg')
+      @new_user = Foo::User.new(fullname: "Mayonegg")
       expect(@new_user).not_to respond_to(:unknown_method_for_a_user)
       expect(@new_user).to respond_to(:fullname)
     end
@@ -49,24 +49,23 @@ describe Her::Model::Attributes do
     end
 
     it "handles has_attribute? for getter" do
-      @new_user = Foo::User.new(fullname: 'Mayonegg')
+      @new_user = Foo::User.new(fullname: "Mayonegg")
       expect(@new_user).not_to have_attribute(:unknown_method_for_a_user)
       expect(@new_user).to have_attribute(:fullname)
     end
 
     it "handles get_attribute for getter" do
-      @new_user = Foo::User.new(fullname: 'Mayonegg')
+      @new_user = Foo::User.new(fullname: "Mayonegg")
       expect(@new_user.get_attribute(:unknown_method_for_a_user)).to be_nil
-      expect(@new_user.get_attribute(:fullname)).to eq('Mayonegg')
+      expect(@new_user.get_attribute(:fullname)).to eq("Mayonegg")
     end
 
     it "handles get_attribute for getter with dash" do
-      @new_user = Foo::User.new(:'life-span' => '3 years')
+      @new_user = Foo::User.new(:'life-span' => "3 years")
       expect(@new_user.get_attribute(:unknown_method_for_a_user)).to be_nil
-      expect(@new_user.get_attribute(:'life-span')).to eq('3 years')
+      expect(@new_user.get_attribute(:'life-span')).to eq("3 years")
     end
   end
-
 
   context "assigning new resource data" do
     before do
@@ -86,9 +85,9 @@ describe Her::Model::Attributes do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
-          stub.get("/admins/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/2") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.get("/admins/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
         end
       end
 
@@ -139,7 +138,7 @@ describe Her::Model::Attributes do
       hash = { user => true }
       hash[Foo::User.find(1)] = false
       expect(hash.size).to eq(1)
-      expect(hash).to eq({ user => false })
+      expect(hash).to eq(user => false)
     end
   end
 
@@ -148,20 +147,20 @@ describe Her::Model::Attributes do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
       end
 
-      spawn_model 'Foo::User' do
+      spawn_model "Foo::User" do
         store_response_errors :errors
         store_metadata :my_data
       end
 
-      @user = Foo::User.new(_errors: ["Foo", "Bar"], _metadata: { secret: true })
+      @user = Foo::User.new(_errors: %w(Foo Bar), _metadata: { secret: true })
     end
 
     it "should return response_errors stored in the method provided by `store_response_errors`" do
-      expect(@user.errors).to eq(["Foo", "Bar"])
+      expect(@user.errors).to eq(%w(Foo Bar))
     end
 
     it "should remove the default method for errors" do
@@ -169,7 +168,7 @@ describe Her::Model::Attributes do
     end
 
     it "should return metadata stored in the method provided by `store_metadata`" do
-      expect(@user.my_data).to eq({ secret: true })
+      expect(@user.my_data).to eq(secret: true)
     end
 
     it "should remove the default method for metadata" do
@@ -191,11 +190,11 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
-        spawn_model 'Foo::User' do
+        spawn_model "Foo::User" do
           def document
             @attributes[:document][:url]
           end
@@ -216,11 +215,11 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
-        spawn_model 'Foo::User' do
+        spawn_model "Foo::User" do
           def document=(document)
             @attributes[:document] = document[:url]
           end
@@ -241,12 +240,12 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", document: { url: nil } }.to_json] }
-            stub.get("/users/2") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", document: { url: nil } }.to_json] }
+            stub.get("/users/2") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
-        spawn_model 'Foo::User' do
+        spawn_model "Foo::User" do
           def document?
             document[:url].present?
           end
@@ -268,7 +267,7 @@ describe Her::Model::Attributes do
 
   context "attributes class method" do
     before do
-      spawn_model 'Foo::User' do
+      spawn_model "Foo::User" do
         attributes :fullname, :document
       end
     end
@@ -283,20 +282,20 @@ describe Her::Model::Attributes do
 
     it "defines setter that affects @attributes" do
       user = Foo::User.new
-      user.fullname = 'Tobias Fünke'
-      expect(user.attributes[:fullname]).to eq('Tobias Fünke')
+      user.fullname = "Tobias Fünke"
+      expect(user.attributes[:fullname]).to eq("Tobias Fünke")
     end
 
     it "defines getter that reads @attributes" do
       user = Foo::User.new
-      user.assign_attributes(fullname: 'Tobias Fünke')
-      expect(user.fullname).to eq('Tobias Fünke')
+      user.assign_attributes(fullname: "Tobias Fünke")
+      expect(user.fullname).to eq("Tobias Fünke")
     end
 
     it "defines predicate that reads @attributes" do
       user = Foo::User.new
       expect(user.fullname?).to be_falsey
-      user.assign_attributes(fullname: 'Tobias Fünke')
+      user.assign_attributes(fullname: "Tobias Fünke")
       expect(user.fullname?).to be_truthy
     end
 
@@ -311,7 +310,7 @@ describe Her::Model::Attributes do
         end
         @spawned_models << :AbstractUser
 
-        spawn_model 'Foo::User', super_class: AbstractUser do
+        spawn_model "Foo::User", super_class: AbstractUser do
           attributes :fullname
         end
       end
@@ -330,20 +329,20 @@ describe Her::Model::Attributes do
 
       it "defines setter that affects @attributes" do
         user = Foo::User.new
-        user.fullname = 'Tobias Fünke'
-        expect(user.attributes[:fullname]).to eq('Tobias Fünke')
+        user.fullname = "Tobias Fünke"
+        expect(user.attributes[:fullname]).to eq("Tobias Fünke")
       end
 
       it "defines getter that reads @attributes" do
         user = Foo::User.new
-        user.attributes[:fullname] = 'Tobias Fünke'
-        expect(user.fullname).to eq('Tobias Fünke')
+        user.attributes[:fullname] = "Tobias Fünke"
+        expect(user.fullname).to eq("Tobias Fünke")
       end
 
       it "defines predicate that reads @attributes" do
         user = Foo::User.new
         expect(user.fullname?).to be_falsey
-        user.attributes[:fullname] = 'Tobias Fünke'
+        user.attributes[:fullname] = "Tobias Fünke"
         expect(user.fullname?).to be_truthy
       end
     end
@@ -351,7 +350,7 @@ describe Her::Model::Attributes do
     if ActiveModel::VERSION::MAJOR < 4
       it "creates a new mutex" do
         expect(Mutex).to receive(:new).once.and_call_original
-        spawn_model 'Foo::User' do
+        spawn_model "Foo::User" do
           attributes :fullname
         end
         expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
@@ -359,12 +358,12 @@ describe Her::Model::Attributes do
 
       it "works well with Module#synchronize monkey patched by ActiveSupport" do
         Module.class_eval do
-          def synchronize(*args)
-            raise 'gotcha!'
+          def synchronize(*_args)
+            raise "gotcha!"
           end
         end
         expect(Mutex).to receive(:new).once.and_call_original
-        spawn_model 'Foo::User' do
+        spawn_model "Foo::User" do
           attributes :fullname
         end
         expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
@@ -379,7 +378,7 @@ describe Her::Model::Attributes do
     end
 
     it "uses a mutex" do
-      spawn_model 'Foo::User'
+      spawn_model "Foo::User"
       expect(Foo::User.attribute_methods_mutex).to receive(:synchronize).once.and_call_original
       Foo::User.class_eval do
         attributes :fullname, :documents

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -6,7 +6,7 @@ describe Her::Model::Attributes do
     before { spawn_model "Foo::User" }
 
     it "handles new resource" do
-      @new_user = Foo::User.new(:fullname => "Tobias Fünke")
+      @new_user = Foo::User.new(fullname: "Tobias Fünke")
       expect(@new_user.new?).to be_truthy
       expect(@new_user.fullname).to eq("Tobias Fünke")
     end
@@ -17,7 +17,7 @@ describe Her::Model::Attributes do
     end
 
     it "handles method missing for getter" do
-      @new_user = Foo::User.new(:fullname => 'Mayonegg')
+      @new_user = Foo::User.new(fullname: 'Mayonegg')
       expect { @new_user.unknown_method_for_a_user }.to raise_error(NoMethodError)
       expect { @new_user.fullname }.not_to raise_error()
     end
@@ -33,7 +33,7 @@ describe Her::Model::Attributes do
     end
 
     it "handles respond_to for getter" do
-      @new_user = Foo::User.new(:fullname => 'Mayonegg')
+      @new_user = Foo::User.new(fullname: 'Mayonegg')
       expect(@new_user).not_to respond_to(:unknown_method_for_a_user)
       expect(@new_user).to respond_to(:fullname)
     end
@@ -49,13 +49,13 @@ describe Her::Model::Attributes do
     end
 
     it "handles has_attribute? for getter" do
-      @new_user = Foo::User.new(:fullname => 'Mayonegg')
+      @new_user = Foo::User.new(fullname: 'Mayonegg')
       expect(@new_user).not_to have_attribute(:unknown_method_for_a_user)
       expect(@new_user).to have_attribute(:fullname)
     end
 
     it "handles get_attribute for getter" do
-      @new_user = Foo::User.new(:fullname => 'Mayonegg')
+      @new_user = Foo::User.new(fullname: 'Mayonegg')
       expect(@new_user.get_attribute(:unknown_method_for_a_user)).to be_nil
       expect(@new_user.get_attribute(:fullname)).to eq('Mayonegg')
     end
@@ -71,24 +71,24 @@ describe Her::Model::Attributes do
   context "assigning new resource data" do
     before do
       spawn_model "Foo::User"
-      @user = Foo::User.new(:active => false)
+      @user = Foo::User.new(active: false)
     end
 
     it "handles data update through #assign_attributes" do
-      @user.assign_attributes :active => true
+      @user.assign_attributes active: true
       expect(@user).to be_active
     end
   end
 
   context "checking resource equality" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke" }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke" }.to_json] }
-          stub.get("/admins/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.get("/admins/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
         end
       end
 
@@ -107,7 +107,7 @@ describe Her::Model::Attributes do
     end
 
     it "returns true for the same class with identical data" do
-      expect(user).to eq(Foo::User.new(:id => 1, :fullname => "Lindsay Fünke"))
+      expect(user).to eq(Foo::User.new(id: 1, fullname: "Lindsay Fünke"))
     end
 
     it "returns true for a different resource with the same data" do
@@ -115,11 +115,11 @@ describe Her::Model::Attributes do
     end
 
     it "returns false for the same class with different data" do
-      expect(user).not_to eq(Foo::User.new(:id => 2, :fullname => "Tobias Fünke"))
+      expect(user).not_to eq(Foo::User.new(id: 2, fullname: "Tobias Fünke"))
     end
 
     it "returns false for a non-resource with the same data" do
-      fake_user = double(:data => { :id => 1, :fullname => "Lindsay Fünke" })
+      fake_user = double(data: { id: 1, fullname: "Lindsay Fünke" })
       expect(user).not_to eq(fake_user)
     end
 
@@ -145,10 +145,10 @@ describe Her::Model::Attributes do
 
   context "handling metadata and errors" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke" }.to_json] }
+          stub.post("/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -157,7 +157,7 @@ describe Her::Model::Attributes do
         store_metadata :my_data
       end
 
-      @user = Foo::User.new(:_errors => ["Foo", "Bar"], :_metadata => { :secret => true })
+      @user = Foo::User.new(_errors: ["Foo", "Bar"], _metadata: { secret: true })
     end
 
     it "should return response_errors stored in the method provided by `store_response_errors`" do
@@ -169,7 +169,7 @@ describe Her::Model::Attributes do
     end
 
     it "should return metadata stored in the method provided by `store_metadata`" do
-      expect(@user.my_data).to eq({ :secret => true })
+      expect(@user.my_data).to eq({ secret: true })
     end
 
     it "should remove the default method for metadata" do
@@ -177,7 +177,7 @@ describe Her::Model::Attributes do
     end
 
     it "should work with #save" do
-      @user.assign_attributes(:fullname => "Tobias Fünke")
+      @user.assign_attributes(fullname: "Tobias Fünke")
       @user.save
       expect { @user.metadata }.to raise_error(NoMethodError)
       expect(@user.my_data).to be_empty
@@ -188,10 +188,10 @@ describe Her::Model::Attributes do
   context "overwriting default attribute methods" do
     context "for getter method" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :document => { :url => "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
@@ -213,10 +213,10 @@ describe Her::Model::Attributes do
 
     context "for setter method" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :document => { :url => "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
@@ -238,11 +238,11 @@ describe Her::Model::Attributes do
 
     context "for predicate method" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke", :document => { :url => nil } }.to_json] }
-            stub.get("/users/2") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :document => { :url => "http://example.com" } }.to_json] }
+            stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", document: { url: nil } }.to_json] }
+            stub.get("/users/2") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -7,13 +7,13 @@ describe Her::Model::Attributes do
 
     it "handles new resource" do
       @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-      @new_user.new?.should be_truthy
-      @new_user.fullname.should == "Tobias Fünke"
+      expect(@new_user.new?).to be_truthy
+      expect(@new_user.fullname).to eq("Tobias Fünke")
     end
 
     it "accepts new resource with strings as hash keys" do
       @new_user = Foo::User.new('fullname' => "Tobias Fünke")
-      @new_user.fullname.should == "Tobias Fünke"
+      expect(@new_user.fullname).to eq("Tobias Fünke")
     end
 
     it "handles method missing for getter" do
@@ -34,36 +34,36 @@ describe Her::Model::Attributes do
 
     it "handles respond_to for getter" do
       @new_user = Foo::User.new(:fullname => 'Mayonegg')
-      @new_user.should_not respond_to(:unknown_method_for_a_user)
-      @new_user.should respond_to(:fullname)
+      expect(@new_user).not_to respond_to(:unknown_method_for_a_user)
+      expect(@new_user).to respond_to(:fullname)
     end
 
     it "handles respond_to for setter" do
       @new_user = Foo::User.new
-      @new_user.should respond_to(:fullname=)
+      expect(@new_user).to respond_to(:fullname=)
     end
 
     it "handles respond_to for query" do
       @new_user = Foo::User.new
-      @new_user.should respond_to(:fullname?)
+      expect(@new_user).to respond_to(:fullname?)
     end
 
     it "handles has_attribute? for getter" do
       @new_user = Foo::User.new(:fullname => 'Mayonegg')
-      @new_user.should_not have_attribute(:unknown_method_for_a_user)
-      @new_user.should have_attribute(:fullname)
+      expect(@new_user).not_to have_attribute(:unknown_method_for_a_user)
+      expect(@new_user).to have_attribute(:fullname)
     end
 
     it "handles get_attribute for getter" do
       @new_user = Foo::User.new(:fullname => 'Mayonegg')
-      @new_user.get_attribute(:unknown_method_for_a_user).should be_nil
-      @new_user.get_attribute(:fullname).should == 'Mayonegg'
+      expect(@new_user.get_attribute(:unknown_method_for_a_user)).to be_nil
+      expect(@new_user.get_attribute(:fullname)).to eq('Mayonegg')
     end
 
     it "handles get_attribute for getter with dash" do
       @new_user = Foo::User.new(:'life-span' => '3 years')
-      @new_user.get_attribute(:unknown_method_for_a_user).should be_nil
-      @new_user.get_attribute(:'life-span').should == '3 years'
+      expect(@new_user.get_attribute(:unknown_method_for_a_user)).to be_nil
+      expect(@new_user.get_attribute(:'life-span')).to eq('3 years')
     end
   end
 
@@ -76,7 +76,7 @@ describe Her::Model::Attributes do
 
     it "handles data update through #assign_attributes" do
       @user.assign_attributes :active => true
-      @user.should be_active
+      expect(@user).to be_active
     end
   end
 
@@ -99,47 +99,47 @@ describe Her::Model::Attributes do
     let(:user) { Foo::User.find(1) }
 
     it "returns true for the exact same object" do
-      user.should == user
+      expect(user).to eq(user)
     end
 
     it "returns true for the same resource via find" do
-      user.should == Foo::User.find(1)
+      expect(user).to eq(Foo::User.find(1))
     end
 
     it "returns true for the same class with identical data" do
-      user.should == Foo::User.new(:id => 1, :fullname => "Lindsay Fünke")
+      expect(user).to eq(Foo::User.new(:id => 1, :fullname => "Lindsay Fünke"))
     end
 
     it "returns true for a different resource with the same data" do
-      user.should == Foo::Admin.find(1)
+      expect(user).to eq(Foo::Admin.find(1))
     end
 
     it "returns false for the same class with different data" do
-      user.should_not == Foo::User.new(:id => 2, :fullname => "Tobias Fünke")
+      expect(user).not_to eq(Foo::User.new(:id => 2, :fullname => "Tobias Fünke"))
     end
 
     it "returns false for a non-resource with the same data" do
       fake_user = double(:data => { :id => 1, :fullname => "Lindsay Fünke" })
-      user.should_not == fake_user
+      expect(user).not_to eq(fake_user)
     end
 
     it "delegates eql? to ==" do
       other = Object.new
-      user.should_receive(:==).with(other).and_return(true)
-      user.eql?(other).should be_truthy
+      expect(user).to receive(:==).with(other).and_return(true)
+      expect(user.eql?(other)).to be_truthy
     end
 
     it "treats equal resources as equal for Array#uniq" do
       user2 = Foo::User.find(1)
-      [user, user2].uniq.should == [user]
+      expect([user, user2].uniq).to eq([user])
     end
 
     it "treats equal resources as equal for hash keys" do
       Foo::User.find(1)
       hash = { user => true }
       hash[Foo::User.find(1)] = false
-      hash.size.should == 1
-      hash.should == { user => false }
+      expect(hash.size).to eq(1)
+      expect(hash).to eq({ user => false })
     end
   end
 
@@ -161,7 +161,7 @@ describe Her::Model::Attributes do
     end
 
     it "should return response_errors stored in the method provided by `store_response_errors`" do
-      @user.errors.should == ["Foo", "Bar"]
+      expect(@user.errors).to eq(["Foo", "Bar"])
     end
 
     it "should remove the default method for errors" do
@@ -169,7 +169,7 @@ describe Her::Model::Attributes do
     end
 
     it "should return metadata stored in the method provided by `store_metadata`" do
-      @user.my_data.should == { :secret => true }
+      expect(@user.my_data).to eq({ :secret => true })
     end
 
     it "should remove the default method for metadata" do
@@ -180,8 +180,8 @@ describe Her::Model::Attributes do
       @user.assign_attributes(:fullname => "Tobias Fünke")
       @user.save
       expect { @user.metadata }.to raise_error(NoMethodError)
-      @user.my_data.should be_empty
-      @user.errors.should be_empty
+      expect(@user.my_data).to be_empty
+      expect(@user.errors).to be_empty
     end
   end
 
@@ -204,10 +204,10 @@ describe Her::Model::Attributes do
 
       it "bypasses Her's method" do
         @user = Foo::User.find(1)
-        @user.document.should == "http://example.com"
+        expect(@user.document).to eq("http://example.com")
 
         @user = Foo::User.find(1)
-        @user.document.should == "http://example.com"
+        expect(@user.document).to eq("http://example.com")
       end
     end
 
@@ -229,10 +229,10 @@ describe Her::Model::Attributes do
 
       it "bypasses Her's method" do
         @user = Foo::User.find(1)
-        @user.document.should == "http://example.com"
+        expect(@user.document).to eq("http://example.com")
 
         @user = Foo::User.find(1)
-        @user.document.should == "http://example.com"
+        expect(@user.document).to eq("http://example.com")
       end
     end
 
@@ -255,13 +255,13 @@ describe Her::Model::Attributes do
 
       it "byoasses Her's method" do
         @user = Foo::User.find(1)
-        @user.document?.should be_falsey
+        expect(@user.document?).to be_falsey
 
         @user = Foo::User.find(1)
-        @user.document?.should be_falsey
+        expect(@user.document?).to be_falsey
 
         @user = Foo::User.find(2)
-        @user.document?.should be_truthy
+        expect(@user.document?).to be_truthy
       end
     end
   end
@@ -276,28 +276,28 @@ describe Her::Model::Attributes do
     context "instance" do
       subject { Foo::User.new }
 
-      it { should respond_to(:fullname) }
-      it { should respond_to(:fullname=) }
-      it { should respond_to(:fullname?) }
+      it { is_expected.to respond_to(:fullname) }
+      it { is_expected.to respond_to(:fullname=) }
+      it { is_expected.to respond_to(:fullname?) }
     end
 
     it "defines setter that affects @attributes" do
       user = Foo::User.new
       user.fullname = 'Tobias Fünke'
-      user.attributes[:fullname].should eq('Tobias Fünke')
+      expect(user.attributes[:fullname]).to eq('Tobias Fünke')
     end
 
     it "defines getter that reads @attributes" do
       user = Foo::User.new
       user.assign_attributes(fullname: 'Tobias Fünke')
-      user.fullname.should eq('Tobias Fünke')
+      expect(user.fullname).to eq('Tobias Fünke')
     end
 
     it "defines predicate that reads @attributes" do
       user = Foo::User.new
-      user.fullname?.should be_falsey
+      expect(user.fullname?).to be_falsey
       user.assign_attributes(fullname: 'Tobias Fünke')
-      user.fullname?.should be_truthy
+      expect(user.fullname?).to be_truthy
     end
 
     context "when attribute methods are already defined" do
@@ -317,34 +317,34 @@ describe Her::Model::Attributes do
       end
 
       it "overrides getter method" do
-        Foo::User.generated_attribute_methods.instance_methods.should include(:fullname)
+        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname)
       end
 
       it "overrides setter method" do
-        Foo::User.generated_attribute_methods.instance_methods.should include(:fullname=)
+        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname=)
       end
 
       it "overrides predicate method" do
-        Foo::User.generated_attribute_methods.instance_methods.should include(:fullname?)
+        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname?)
       end
 
       it "defines setter that affects @attributes" do
         user = Foo::User.new
         user.fullname = 'Tobias Fünke'
-        user.attributes[:fullname].should eq('Tobias Fünke')
+        expect(user.attributes[:fullname]).to eq('Tobias Fünke')
       end
 
       it "defines getter that reads @attributes" do
         user = Foo::User.new
         user.attributes[:fullname] = 'Tobias Fünke'
-        user.fullname.should eq('Tobias Fünke')
+        expect(user.fullname).to eq('Tobias Fünke')
       end
 
       it "defines predicate that reads @attributes" do
         user = Foo::User.new
-        user.fullname?.should be_falsey
+        expect(user.fullname?).to be_falsey
         user.attributes[:fullname] = 'Tobias Fünke'
-        user.fullname?.should be_truthy
+        expect(user.fullname?).to be_truthy
       end
     end
 
@@ -354,7 +354,7 @@ describe Her::Model::Attributes do
         spawn_model 'Foo::User' do
           attributes :fullname
         end
-        Foo::User.attribute_methods_mutex.should_not eq(Foo::User.generated_attribute_methods)
+        expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
       end
 
       it "works well with Module#synchronize monkey patched by ActiveSupport" do
@@ -367,14 +367,14 @@ describe Her::Model::Attributes do
         spawn_model 'Foo::User' do
           attributes :fullname
         end
-        Foo::User.attribute_methods_mutex.should_not eq(Foo::User.generated_attribute_methods)
+        expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
         Module.class_eval do
           undef :synchronize
         end
       end
     else
       it "uses ActiveModel's mutex" do
-        Foo::User.attribute_methods_mutex.should eq(Foo::User.generated_attribute_methods)
+        expect(Foo::User.attribute_methods_mutex).to eq(Foo::User.generated_attribute_methods)
       end
     end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -85,9 +85,9 @@ describe Her::Model::Attributes do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
-          stub.get("/admins/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.get("/admins/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
         end
       end
 
@@ -147,7 +147,7 @@ describe Her::Model::Attributes do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.post("/users") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.post("/users") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -190,7 +190,7 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
@@ -215,7 +215,7 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 
@@ -240,8 +240,8 @@ describe Her::Model::Attributes do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", document: { url: nil } }.to_json] }
-            stub.get("/users/2") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
+            stub.get("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", document: { url: nil } }.to_json] }
+            stub.get("/users/2") { [200, {}, { id: 1, fullname: "Tobias Fünke", document: { url: "http://example.com" } }.to_json] }
           end
         end
 

--- a/spec/model/callbacks_spec.rb
+++ b/spec/model/callbacks_spec.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 
 describe "Her::Model and ActiveModel::Callbacks" do
   before do
-    Her::API.setup :url => "https://api.example.com" do |builder|
+    Her::API.setup url: "https://api.example.com" do |builder|
       builder.use Her::Middleware::FirstLevelParseJSON
     end
 
@@ -11,11 +11,11 @@ describe "Her::Model and ActiveModel::Callbacks" do
   end
 
   context :before_save do
-    subject { Foo::User.create(:name => "Tobias Funke") }
+    subject { Foo::User.create(name: "Tobias Funke") }
     before do
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.post("/users") { |env| [200, {}, { :id => 1, :name => env[:body][:name] }.to_json] }
-        stub.put("/users/1") { |env| [200, {}, { :id => 1, :name => env[:body][:name] }.to_json] }
+        stub.post("/users") { |env| [200, {}, { id: 1, name: env[:body][:name] }.to_json] }
+        stub.put("/users/1") { |env| [200, {}, { id: 1, name: env[:body][:name] }.to_json] }
       end
     end
 
@@ -65,10 +65,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
   end
 
   context :before_create do
-    subject { Foo::User.create(:name => "Tobias Funke") }
+    subject { Foo::User.create(name: "Tobias Funke") }
     before do
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.post("/users") { |env| [200, {}, { :id => 1, :name => env[:body][:name] }.to_json] }
+        stub.post("/users") { |env| [200, {}, { id: 1, name: env[:body][:name] }.to_json] }
       end
     end
 
@@ -104,7 +104,7 @@ describe "Her::Model and ActiveModel::Callbacks" do
     subject { Foo::User.find(1) }
     before do
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
+        stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
       end
     end
 
@@ -137,7 +137,7 @@ describe "Her::Model and ActiveModel::Callbacks" do
   end
 
   context :after_initialize do
-    subject { Foo::User.new(:name => "Tobias Funke") }
+    subject { Foo::User.new(name: "Tobias Funke") }
 
     context "when using a symbol callback" do
       before do

--- a/spec/model/callbacks_spec.rb
+++ b/spec/model/callbacks_spec.rb
@@ -23,11 +23,13 @@ describe "Her::Model and ActiveModel::Callbacks" do
       before do
         class Foo::User
           before_save :alter_name
-          def alter_name; self.name.upcase!;  end
+          def alter_name
+            name.upcase!
+          end
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -36,11 +38,11 @@ describe "Her::Model and ActiveModel::Callbacks" do
     context "when using a block callback" do
       before do
         class Foo::User
-          before_save lambda { self.name.upcase! }
+          before_save -> { name.upcase! }
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -76,11 +78,13 @@ describe "Her::Model and ActiveModel::Callbacks" do
       before do
         class Foo::User
           before_create :alter_name
-          def alter_name; self.name.upcase!;  end
+          def alter_name
+            name.upcase!
+          end
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -89,11 +93,11 @@ describe "Her::Model and ActiveModel::Callbacks" do
     context "when using a block callback" do
       before do
         class Foo::User
-          before_create lambda { self.name.upcase! }
+          before_create -> { name.upcase! }
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -104,7 +108,7 @@ describe "Her::Model and ActiveModel::Callbacks" do
     subject { Foo::User.find(1) }
     before do
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+        stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
       end
     end
 
@@ -112,11 +116,13 @@ describe "Her::Model and ActiveModel::Callbacks" do
       before do
         class Foo::User
           after_find :alter_name
-          def alter_name; self.name.upcase!;  end
+          def alter_name
+            name.upcase!
+          end
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -125,11 +131,11 @@ describe "Her::Model and ActiveModel::Callbacks" do
     context "when using a block callback" do
       before do
         class Foo::User
-          after_find lambda { self.name.upcase! }
+          after_find -> { name.upcase! }
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -143,11 +149,13 @@ describe "Her::Model and ActiveModel::Callbacks" do
       before do
         class Foo::User
           after_initialize :alter_name
-          def alter_name; self.name.upcase!;  end
+          def alter_name
+            name.upcase!
+          end
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end
@@ -156,11 +164,11 @@ describe "Her::Model and ActiveModel::Callbacks" do
     context "when using a block callback" do
       before do
         class Foo::User
-          after_initialize lambda { self.name.upcase! }
+          after_initialize -> { name.upcase! }
         end
       end
 
-      describe '#name' do
+      describe "#name" do
         subject { super().name }
         it { is_expected.to eq("TOBIAS FUNKE") }
       end

--- a/spec/model/callbacks_spec.rb
+++ b/spec/model/callbacks_spec.rb
@@ -108,7 +108,7 @@ describe "Her::Model and ActiveModel::Callbacks" do
     subject { Foo::User.find(1) }
     before do
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+        stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
       end
     end
 

--- a/spec/model/callbacks_spec.rb
+++ b/spec/model/callbacks_spec.rb
@@ -27,7 +27,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
 
     context "when using a block callback" do
@@ -37,7 +40,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
 
     context "when changing a value of an existing resource in a callback" do
@@ -51,9 +57,9 @@ describe "Her::Model and ActiveModel::Callbacks" do
       end
 
       it "should call the server with the canged value" do
-        subject.name.should == "Tobias Funke"
+        expect(subject.name).to eq("Tobias Funke")
         subject.save
-        subject.name.should == "Lumberjack"
+        expect(subject.name).to eq("Lumberjack")
       end
     end
   end
@@ -74,7 +80,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
 
     context "when using a block callback" do
@@ -84,7 +93,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
   end
 
@@ -104,7 +116,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
 
     context "when using a block callback" do
@@ -114,7 +129,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
   end
 
@@ -129,7 +147,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
 
     context "when using a block callback" do
@@ -139,7 +160,10 @@ describe "Her::Model and ActiveModel::Callbacks" do
         end
       end
 
-      its(:name) { should == "TOBIAS FUNKE" }
+      describe '#name' do
+        subject { super().name }
+        it { is_expected.to eq("TOBIAS FUNKE") }
+      end
     end
   end
 end

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -4,16 +4,16 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 describe "Her::Model and ActiveModel::Dirty" do
   context "checking dirty attributes" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke" }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 2, :fullname => "Maeby Fünke" }.to_json] }
-          stub.get("/users/3") { |env| [200, {}, { :user_id => 3, :fullname => "Maeby Fünke" }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke" }.to_json] }
-          stub.put("/users/2") { |env| [400, {}, { :errors => ["Email cannot be blank"] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 2, fullname: "Maeby Fünke" }.to_json] }
+          stub.get("/users/3") { |env| [200, {}, { user_id: 3, fullname: "Maeby Fünke" }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.put("/users/2") { |env| [400, {}, { errors: ["Email cannot be blank"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -49,12 +49,12 @@ describe "Her::Model and ActiveModel::Dirty" do
         it "tracks previous changes" do
           user.fullname = "Tobias Fünke"
           user.save
-          expect(user.previous_changes).to eq({"fullname"=>"Lindsay Fünke"})
+          expect(user.previous_changes).to eq("fullname"=>"Lindsay Fünke")
         end
 
         it 'tracks dirty attribute for mass assign for dynamic created attributes' do
           user = Dynamic::User.find(3)
-          user.assign_attributes(:fullname => 'New Fullname')
+          user.assign_attributes(fullname: 'New Fullname')
           expect(user.fullname_changed?).to be_truthy
           expect(user).to be_changed
           expect(user.changes.length).to eq(1)
@@ -75,7 +75,7 @@ describe "Her::Model and ActiveModel::Dirty" do
     end
 
     context "for new resource" do
-      let(:user) { Foo::User.new(:fullname => "Lindsay Fünke") }
+      let(:user) { Foo::User.new(fullname: "Lindsay Fünke") }
       it "has changes" do
         expect(user).to be_changed
       end

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -28,36 +28,36 @@ describe "Her::Model and ActiveModel::Dirty" do
     context "for existing resource" do
       let(:user) { Foo::User.find(1) }
       it "has no changes" do
-        user.changes.should be_empty
-        user.should_not be_changed
+        expect(user.changes).to be_empty
+        expect(user).not_to be_changed
       end
       context "with successful save" do
         it "tracks dirty attributes" do
           user.fullname = "Tobias Fünke"
-          user.fullname_changed?.should be_truthy
-          user.email_changed?.should be_falsey
-          user.should be_changed
+          expect(user.fullname_changed?).to be_truthy
+          expect(user.email_changed?).to be_falsey
+          expect(user).to be_changed
           user.save
-          user.should_not be_changed
+          expect(user).not_to be_changed
         end
 
         it "tracks only changed dirty attributes" do
           user.fullname = user.fullname
-          user.fullname_changed?.should be_falsey
+          expect(user.fullname_changed?).to be_falsey
         end
 
         it "tracks previous changes" do
           user.fullname = "Tobias Fünke"
           user.save
-          user.previous_changes.should eq({"fullname"=>"Lindsay Fünke"})
+          expect(user.previous_changes).to eq({"fullname"=>"Lindsay Fünke"})
         end
 
         it 'tracks dirty attribute for mass assign for dynamic created attributes' do
           user = Dynamic::User.find(3)
           user.assign_attributes(:fullname => 'New Fullname')
-          user.fullname_changed?.should be_truthy
-          user.should be_changed
-          user.changes.length.should eq(1)
+          expect(user.fullname_changed?).to be_truthy
+          expect(user).to be_changed
+          expect(user.changes.length).to eq(1)
         end
       end
 
@@ -65,11 +65,11 @@ describe "Her::Model and ActiveModel::Dirty" do
         it "tracks dirty attributes" do
           user = Foo::User.find(2)
           user.fullname = "Tobias Fünke"
-          user.fullname_changed?.should be_truthy
-          user.email_changed?.should be_falsey
-          user.should be_changed
+          expect(user.fullname_changed?).to be_truthy
+          expect(user.email_changed?).to be_falsey
+          expect(user).to be_changed
           user.save
-          user.should be_changed
+          expect(user).to be_changed
         end
       end
     end
@@ -77,14 +77,14 @@ describe "Her::Model and ActiveModel::Dirty" do
     context "for new resource" do
       let(:user) { Foo::User.new(:fullname => "Lindsay Fünke") }
       it "has changes" do
-        user.should be_changed
+        expect(user).to be_changed
       end
       it "tracks dirty attributes" do
         user.fullname = "Tobias Fünke"
-        user.fullname_changed?.should be_truthy
-        user.should be_changed
+        expect(user.fullname_changed?).to be_truthy
+        expect(user).to be_changed
         user.save
-        user.should_not be_changed
+        expect(user).not_to be_changed
       end
     end
   end

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -8,12 +8,12 @@ describe "Her::Model and ActiveModel::Dirty" do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { id: 2, fullname: "Maeby Fünke" }.to_json] }
-          stub.get("/users/3") { |env| [200, {}, { user_id: 3, fullname: "Maeby Fünke" }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
-          stub.put("/users/2") { |env| [400, {}, { errors: ["Email cannot be blank"] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 2, fullname: "Maeby Fünke" }.to_json] }
+          stub.get("/users/3") { [200, {}, { user_id: 3, fullname: "Maeby Fünke" }.to_json] }
+          stub.put("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.put("/users/2") { [400, {}, { errors: ["Email cannot be blank"] }.to_json] }
+          stub.post("/users")  { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -49,12 +49,12 @@ describe "Her::Model and ActiveModel::Dirty" do
         it "tracks previous changes" do
           user.fullname = "Tobias Fünke"
           user.save
-          expect(user.previous_changes).to eq("fullname"=>"Lindsay Fünke")
+          expect(user.previous_changes).to eq("fullname" => "Lindsay Fünke")
         end
 
-        it 'tracks dirty attribute for mass assign for dynamic created attributes' do
+        it "tracks dirty attribute for mass assign for dynamic created attributes" do
           user = Dynamic::User.find(3)
-          user.assign_attributes(fullname: 'New Fullname')
+          user.assign_attributes(fullname: "New Fullname")
           expect(user.fullname_changed?).to be_truthy
           expect(user).to be_changed
           expect(user.changes.length).to eq(1)
@@ -89,3 +89,4 @@ describe "Her::Model and ActiveModel::Dirty" do
     end
   end
 end
+#

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -40,8 +40,8 @@ describe Her::Model::HTTP do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {}, [{ id: 1 }].to_json] }
-          stub.get("/users/1") { |env| [200, {}, { id: 1 }.to_json] }
+          stub.get("/users") { |_env| [200, {}, [{ id: 1 }].to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { id: 1 }.to_json] }
           stub.get("/users/popular") do |env|
             if env[:params]["page"] == "2"
               [200, {}, [{ id: 3 }, { id: 4 }].to_json]
@@ -58,7 +58,7 @@ describe Her::Model::HTTP do
     describe :get do
       subject { Foo::User.get(:popular) }
 
-      describe '#length' do
+      describe "#length" do
         subject { super().length }
         it { is_expected.to eq(2) }
       end
@@ -68,7 +68,7 @@ describe Her::Model::HTTP do
     describe :get_raw do
       context "with a block" do
         specify do
-          Foo::User.get_raw("/users") do |parsed_data, response|
+          Foo::User.get_raw("/users") do |parsed_data, _response|
             expect(parsed_data[:data]).to eq([{ id: 1 }])
           end
         end
@@ -84,7 +84,7 @@ describe Her::Model::HTTP do
       context "with a String path" do
         subject { Foo::User.get_collection("/users/popular") }
 
-        describe '#length' do
+        describe "#length" do
           subject { super().length }
           it { is_expected.to eq(2) }
         end
@@ -94,7 +94,7 @@ describe Her::Model::HTTP do
       context "with a Symbol" do
         subject { Foo::User.get_collection(:popular) }
 
-        describe '#length' do
+        describe "#length" do
           subject { super().length }
           it { is_expected.to eq(2) }
         end
@@ -104,7 +104,7 @@ describe Her::Model::HTTP do
       context "with extra parameters" do
         subject { Foo::User.get_collection(:popular, page: 2) }
 
-        describe '#length' do
+        describe "#length" do
           subject { super().length }
           it { is_expected.to eq(2) }
         end
@@ -116,7 +116,7 @@ describe Her::Model::HTTP do
       context "with a String path" do
         subject { Foo::User.get_resource("/users/1") }
 
-        describe '#id' do
+        describe "#id" do
           subject { super().id }
           it { is_expected.to eq(1) }
         end
@@ -125,7 +125,7 @@ describe Her::Model::HTTP do
       context "with a Symbol" do
         subject { Foo::User.get_resource(:"1") }
 
-        describe '#id' do
+        describe "#id" do
           subject { super().id }
           it { is_expected.to eq(1) }
         end
@@ -134,7 +134,7 @@ describe Her::Model::HTTP do
 
     describe :get_raw do
       specify do
-        Foo::User.get_raw(:popular) do |parsed_data, response|
+        Foo::User.get_raw(:popular) do |parsed_data, _response|
           expect(parsed_data[:data]).to eq([{ id: 1 }, { id: 2 }])
         end
       end
@@ -146,8 +146,8 @@ describe Her::Model::HTTP do
       Her::API.setup url: "https://api.example.com" do |connection|
         connection.use Her::Middleware::FirstLevelParseJSON
         connection.adapter :test do |stub|
-          stub.get("/users/popular") { |env| [200, {}, [{ id: 1 }, { id: 2 }].to_json] }
-          stub.post("/users/from_default") { |env| [200, {}, { id: 4 }.to_json] }
+          stub.get("/users/popular") { |_env| [200, {}, [{ id: 1 }, { id: 2 }].to_json] }
+          stub.post("/users/from_default") { |_env| [200, {}, { id: 4 }.to_json] }
         end
       end
 
@@ -165,7 +165,7 @@ describe Her::Model::HTTP do
         context "making the HTTP request" do
           subject { Foo::User.popular }
 
-          describe '#length' do
+          describe "#length" do
             subject { super().length }
             it { is_expected.to eq(2) }
           end
@@ -180,7 +180,7 @@ describe Her::Model::HTTP do
       context "making the HTTP request" do
         subject { Foo::User.from_default(name: "Tobias Fünke") }
 
-        describe '#id' do
+        describe "#id" do
           subject { super().id }
           it { is_expected.to eq(4) }
         end

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -3,13 +3,13 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 
 describe Her::Model::HTTP do
   context "binding a model with an API" do
-    let(:api1) { Her::API.new :url => "https://api1.example.com" }
-    let(:api2) { Her::API.new :url => "https://api2.example.com" }
+    let(:api1) { Her::API.new url: "https://api1.example.com" }
+    let(:api2) { Her::API.new url: "https://api2.example.com" }
 
     before do
       spawn_model("Foo::User")
       spawn_model("Foo::Comment")
-      Her::API.setup :url => "https://api.example.com"
+      Her::API.setup url: "https://api.example.com"
     end
 
     context "when binding a model to its superclass' her_api" do
@@ -36,17 +36,17 @@ describe Her::Model::HTTP do
 
   context "making HTTP requests" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {}, [{ :id => 1 }].to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :id => 1 }.to_json] }
+          stub.get("/users") { |env| [200, {}, [{ id: 1 }].to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1 }.to_json] }
           stub.get("/users/popular") do |env|
             if env[:params]["page"] == "2"
-              [200, {}, [{ :id => 3 }, { :id => 4 }].to_json]
+              [200, {}, [{ id: 3 }, { id: 4 }].to_json]
             else
-              [200, {}, [{ :id => 1 }, { :id => 2 }].to_json]
+              [200, {}, [{ id: 1 }, { id: 2 }].to_json]
             end
           end
         end
@@ -69,14 +69,14 @@ describe Her::Model::HTTP do
       context "with a block" do
         specify do
           Foo::User.get_raw("/users") do |parsed_data, response|
-            expect(parsed_data[:data]).to eq([{ :id => 1 }])
+            expect(parsed_data[:data]).to eq([{ id: 1 }])
           end
         end
       end
 
       context "with a return value" do
         subject { Foo::User.get_raw("/users") }
-        specify { expect(subject[:parsed_data][:data]).to eq([{ :id => 1 }]) }
+        specify { expect(subject[:parsed_data][:data]).to eq([{ id: 1 }]) }
       end
     end
 
@@ -102,7 +102,7 @@ describe Her::Model::HTTP do
       end
 
       context "with extra parameters" do
-        subject { Foo::User.get_collection(:popular, :page => 2) }
+        subject { Foo::User.get_collection(:popular, page: 2) }
 
         describe '#length' do
           subject { super().length }
@@ -135,7 +135,7 @@ describe Her::Model::HTTP do
     describe :get_raw do
       specify do
         Foo::User.get_raw(:popular) do |parsed_data, response|
-          expect(parsed_data[:data]).to eq([{ :id => 1 }, { :id => 2 }])
+          expect(parsed_data[:data]).to eq([{ id: 1 }, { id: 2 }])
         end
       end
     end
@@ -143,11 +143,11 @@ describe Her::Model::HTTP do
 
   context "setting custom HTTP requests" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |connection|
+      Her::API.setup url: "https://api.example.com" do |connection|
         connection.use Her::Middleware::FirstLevelParseJSON
         connection.adapter :test do |stub|
-          stub.get("/users/popular") { |env| [200, {}, [{ :id => 1 }, { :id => 2 }].to_json] }
-          stub.post("/users/from_default") { |env| [200, {}, { :id => 4 }.to_json] }
+          stub.get("/users/popular") { |env| [200, {}, [{ id: 1 }, { id: 2 }].to_json] }
+          stub.post("/users/from_default") { |env| [200, {}, { id: 4 }.to_json] }
         end
       end
 
@@ -178,7 +178,7 @@ describe Her::Model::HTTP do
       it { is_expected.to respond_to(:from_default) }
 
       context "making the HTTP request" do
-        subject { Foo::User.from_default(:name => "Tobias Fünke") }
+        subject { Foo::User.from_default(name: "Tobias Fünke") }
 
         describe '#id' do
           subject { super().id }

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -19,7 +19,7 @@ describe Her::Model::HTTP do
         Foo::Subclass = Class.new(Foo::Superclass)
       end
 
-      specify { Foo::Subclass.her_api.should == Foo::Superclass.her_api }
+      specify { expect(Foo::Subclass.her_api).to eq(Foo::Superclass.her_api) }
     end
 
     context "when changing her_api without changing the parent class' her_api" do
@@ -30,7 +30,7 @@ describe Her::Model::HTTP do
         Foo::Subclass.uses_api api2
       end
 
-      specify { Foo::Subclass.her_api.should_not == Foo::Superclass.her_api }
+      specify { expect(Foo::Subclass.her_api).not_to eq(Foo::Superclass.her_api) }
     end
   end
 
@@ -57,61 +57,85 @@ describe Her::Model::HTTP do
 
     describe :get do
       subject { Foo::User.get(:popular) }
-      its(:length) { should == 2 }
-      specify { subject.first.id.should == 1 }
+
+      describe '#length' do
+        subject { super().length }
+        it { is_expected.to eq(2) }
+      end
+      specify { expect(subject.first.id).to eq(1) }
     end
 
     describe :get_raw do
       context "with a block" do
         specify do
           Foo::User.get_raw("/users") do |parsed_data, response|
-            parsed_data[:data].should == [{ :id => 1 }]
+            expect(parsed_data[:data]).to eq([{ :id => 1 }])
           end
         end
       end
 
       context "with a return value" do
         subject { Foo::User.get_raw("/users") }
-        specify { subject[:parsed_data][:data].should == [{ :id => 1 }] }
+        specify { expect(subject[:parsed_data][:data]).to eq([{ :id => 1 }]) }
       end
     end
 
     describe :get_collection do
       context "with a String path" do
         subject { Foo::User.get_collection("/users/popular") }
-        its(:length) { should == 2 }
-        specify { subject.first.id.should == 1 }
+
+        describe '#length' do
+          subject { super().length }
+          it { is_expected.to eq(2) }
+        end
+        specify { expect(subject.first.id).to eq(1) }
       end
 
       context "with a Symbol" do
         subject { Foo::User.get_collection(:popular) }
-        its(:length) { should == 2 }
-        specify { subject.first.id.should == 1 }
+
+        describe '#length' do
+          subject { super().length }
+          it { is_expected.to eq(2) }
+        end
+        specify { expect(subject.first.id).to eq(1) }
       end
 
       context "with extra parameters" do
         subject { Foo::User.get_collection(:popular, :page => 2) }
-        its(:length) { should == 2 }
-        specify { subject.first.id.should == 3 }
+
+        describe '#length' do
+          subject { super().length }
+          it { is_expected.to eq(2) }
+        end
+        specify { expect(subject.first.id).to eq(3) }
       end
     end
 
     describe :get_resource do
       context "with a String path" do
         subject { Foo::User.get_resource("/users/1") }
-        its(:id) { should == 1 }
+
+        describe '#id' do
+          subject { super().id }
+          it { is_expected.to eq(1) }
+        end
       end
 
       context "with a Symbol" do
         subject { Foo::User.get_resource(:"1") }
-        its(:id) { should == 1 }
+
+        describe '#id' do
+          subject { super().id }
+          it { is_expected.to eq(1) }
+        end
       end
     end
 
     describe :get_raw do
       specify do
         Foo::User.get_raw(:popular) do |parsed_data, response|
-          parsed_data[:data].should == [{ :id => 1 }, { :id => 2 }]
+          expect(parsed_data[:data]).to eq([{ :id => 1 }, { :id => 2 }])
         end
       end
     end
@@ -135,23 +159,31 @@ describe Her::Model::HTTP do
     describe :custom_get do
       context "without cache" do
         before { Foo::User.custom_get :popular, :recent }
-        it { should respond_to(:popular) }
-        it { should respond_to(:recent) }
+        it { is_expected.to respond_to(:popular) }
+        it { is_expected.to respond_to(:recent) }
 
         context "making the HTTP request" do
           subject { Foo::User.popular }
-          its(:length) { should == 2 }
+
+          describe '#length' do
+            subject { super().length }
+            it { is_expected.to eq(2) }
+          end
         end
       end
     end
 
     describe :custom_post do
       before { Foo::User.custom_post :from_default }
-      it { should respond_to(:from_default) }
+      it { is_expected.to respond_to(:from_default) }
 
       context "making the HTTP request" do
         subject { Foo::User.from_default(:name => "Tobias Fünke") }
-        its(:id) { should == 4 }
+
+        describe '#id' do
+          subject { super().id }
+          it { is_expected.to eq(4) }
+        end
       end
     end
   end

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -40,8 +40,8 @@ describe Her::Model::HTTP do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |_env| [200, {}, [{ id: 1 }].to_json] }
-          stub.get("/users/1") { |_env| [200, {}, { id: 1 }.to_json] }
+          stub.get("/users") { [200, {}, [{ id: 1 }].to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1 }.to_json] }
           stub.get("/users/popular") do |env|
             if env[:params]["page"] == "2"
               [200, {}, [{ id: 3 }, { id: 4 }].to_json]
@@ -146,8 +146,8 @@ describe Her::Model::HTTP do
       Her::API.setup url: "https://api.example.com" do |connection|
         connection.use Her::Middleware::FirstLevelParseJSON
         connection.adapter :test do |stub|
-          stub.get("/users/popular") { |_env| [200, {}, [{ id: 1 }, { id: 2 }].to_json] }
-          stub.post("/users/from_default") { |_env| [200, {}, { id: 4 }.to_json] }
+          stub.get("/users/popular") { [200, {}, [{ id: 1 }, { id: 2 }].to_json] }
+          stub.post("/users/from_default") { [200, {}, { id: 4 }.to_json] }
         end
       end
 

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -8,11 +8,11 @@ describe Her::Model::Introspection do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users")     { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.get("/users/1")    { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.put("/users/1")    { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.delete("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.get("/projects/1/comments") { |_env| [200, {}, [{ id: 1, body: "Hello!" }].to_json] }
+          stub.post("/users")     { [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/users/1")    { [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.put("/users/1")    { [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.delete("/users/1") { [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/projects/1/comments") { [200, {}, [{ id: 1, body: "Hello!" }].to_json] }
         end
       end
 

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -25,25 +25,25 @@ describe Her::Model::Introspection do
     describe "#inspect" do
       it "outputs resource attributes for an existing resource" do
         @user = Foo::User.find(1)
-        ["#<Foo::User(users/1) name=\"Tobias Funke\" id=1>", "#<Foo::User(users/1) id=1 name=\"Tobias Funke\">"].should include(@user.inspect)
+        expect(["#<Foo::User(users/1) name=\"Tobias Funke\" id=1>", "#<Foo::User(users/1) id=1 name=\"Tobias Funke\">"]).to include(@user.inspect)
       end
 
       it "outputs resource attributes for an not-saved-yet resource" do
         @user = Foo::User.new(:name => "Tobias Funke")
-        @user.inspect.should == "#<Foo::User(users) name=\"Tobias Funke\">"
+        expect(@user.inspect).to eq("#<Foo::User(users) name=\"Tobias Funke\">")
       end
 
       it "outputs resource attributes using getters" do
         @user = Foo::User.new(:name => "Tobias Funke", :password => "Funke")
         @user.instance_eval {def password; 'filtered'; end}
-        @user.inspect.should include("name=\"Tobias Funke\"")
-        @user.inspect.should include("password=\"filtered\"")
-        @user.inspect.should_not include("password=\"Funke\"")
+        expect(@user.inspect).to include("name=\"Tobias Funke\"")
+        expect(@user.inspect).to include("password=\"filtered\"")
+        expect(@user.inspect).not_to include("password=\"Funke\"")
       end
 
       it "support dash on attribute" do
         @user = Foo::User.new(:'life-span' => "3 years")
-        @user.inspect.should include("life-span=\"3 years\"")
+        expect(@user.inspect).to include("life-span=\"3 years\"")
       end
     end
 
@@ -51,7 +51,7 @@ describe Her::Model::Introspection do
       it "prints the resource path as “unknown”" do
         @comment = Foo::Comment.where(:project_id => 1).first
         path = '<unknown path, missing `project_id`>'
-        ["#<Foo::Comment(#{path}) body=\"Hello!\" id=1>", "#<Foo::Comment(#{path}) id=1 body=\"Hello!\">"].should include(@comment.inspect)
+        expect(["#<Foo::Comment(#{path}) body=\"Hello!\" id=1>", "#<Foo::Comment(#{path}) id=1 body=\"Hello!\">"]).to include(@comment.inspect)
       end
     end
   end
@@ -66,10 +66,10 @@ describe Her::Model::Introspection do
       end
 
       it "returns a sibling class, if found" do
-        Foo::User.her_nearby_class("AccessRecord").should == Foo::AccessRecord
-        AccessRecord.her_nearby_class("Log").should == Log
-        Foo::User.her_nearby_class("Log").should == Log
-        Foo::User.her_nearby_class("X").should be_nil
+        expect(Foo::User.her_nearby_class("AccessRecord")).to eq(Foo::AccessRecord)
+        expect(AccessRecord.her_nearby_class("Log")).to eq(Log)
+        expect(Foo::User.her_nearby_class("Log")).to eq(Log)
+        expect(Foo::User.her_nearby_class("X")).to be_nil
       end
     end
   end

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -8,11 +8,11 @@ describe Her::Model::Introspection do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users")     { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.get("/users/1")    { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.put("/users/1")    { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.delete("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
-          stub.get("/projects/1/comments") { |env| [200, {}, [{ id: 1, body: "Hello!" }].to_json] }
+          stub.post("/users")     { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/users/1")    { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.put("/users/1")    { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.delete("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/projects/1/comments") { |_env| [200, {}, [{ id: 1, body: "Hello!" }].to_json] }
         end
       end
 
@@ -35,7 +35,11 @@ describe Her::Model::Introspection do
 
       it "outputs resource attributes using getters" do
         @user = Foo::User.new(name: "Tobias Funke", password: "Funke")
-        @user.instance_eval {def password; 'filtered'; end}
+        @user.instance_eval do
+          def password
+            "filtered"
+                             end
+        end
         expect(@user.inspect).to include("name=\"Tobias Funke\"")
         expect(@user.inspect).to include("password=\"filtered\"")
         expect(@user.inspect).not_to include("password=\"Funke\"")
@@ -50,7 +54,7 @@ describe Her::Model::Introspection do
     describe "#inspect with errors in resource path" do
       it "prints the resource path as “unknown”" do
         @comment = Foo::Comment.where(project_id: 1).first
-        path = '<unknown path, missing `project_id`>'
+        path = "<unknown path, missing `project_id`>"
         expect(["#<Foo::Comment(#{path}) body=\"Hello!\" id=1>", "#<Foo::Comment(#{path}) id=1 body=\"Hello!\">"]).to include(@comment.inspect)
       end
     end

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -4,15 +4,15 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 describe Her::Model::Introspection do
   context "introspecting a resource" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users")     { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
-          stub.get("/users/1")    { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
-          stub.put("/users/1")    { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
-          stub.delete("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Funke" }.to_json] }
-          stub.get("/projects/1/comments") { |env| [200, {}, [{ :id => 1, :body => "Hello!" }].to_json] }
+          stub.post("/users")     { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/users/1")    { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.put("/users/1")    { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.delete("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Funke" }.to_json] }
+          stub.get("/projects/1/comments") { |env| [200, {}, [{ id: 1, body: "Hello!" }].to_json] }
         end
       end
 
@@ -29,12 +29,12 @@ describe Her::Model::Introspection do
       end
 
       it "outputs resource attributes for an not-saved-yet resource" do
-        @user = Foo::User.new(:name => "Tobias Funke")
+        @user = Foo::User.new(name: "Tobias Funke")
         expect(@user.inspect).to eq("#<Foo::User(users) name=\"Tobias Funke\">")
       end
 
       it "outputs resource attributes using getters" do
-        @user = Foo::User.new(:name => "Tobias Funke", :password => "Funke")
+        @user = Foo::User.new(name: "Tobias Funke", password: "Funke")
         @user.instance_eval {def password; 'filtered'; end}
         expect(@user.inspect).to include("name=\"Tobias Funke\"")
         expect(@user.inspect).to include("password=\"filtered\"")
@@ -49,7 +49,7 @@ describe Her::Model::Introspection do
 
     describe "#inspect with errors in resource path" do
       it "prints the resource path as “unknown”" do
-        @comment = Foo::Comment.where(:project_id => 1).first
+        @comment = Foo::Comment.where(project_id: 1).first
         path = '<unknown path, missing `project_id`>'
         expect(["#<Foo::Comment(#{path}) body=\"Hello!\" id=1>", "#<Foo::Comment(#{path}) id=1 body=\"Hello!\">"]).to include(@comment.inspect)
       end

--- a/spec/model/nested_attributes_spec.rb
+++ b/spec/model/nested_attributes_spec.rb
@@ -21,16 +21,16 @@ describe Her::Model::NestedAttributes do
 
     context "when child does not yet exist" do
       it "creates an instance of the associated class" do
-        @user_with_data_through_nested_attributes.company.should be_a(Foo::Company)
-        @user_with_data_through_nested_attributes.company.name.should == "Example Company"
+        expect(@user_with_data_through_nested_attributes.company).to be_a(Foo::Company)
+        expect(@user_with_data_through_nested_attributes.company.name).to eq("Example Company")
       end
     end
 
     context "when child does exist" do
       it "updates the attributes of the associated object" do
         @user_with_data_through_nested_attributes.company_attributes = { :name => "Fünke's Company" }
-        @user_with_data_through_nested_attributes.company.should be_a(Foo::Company)
-        @user_with_data_through_nested_attributes.company.name.should == "Fünke's Company"
+        expect(@user_with_data_through_nested_attributes.company).to be_a(Foo::Company)
+        expect(@user_with_data_through_nested_attributes.company.name).to eq("Fünke's Company")
       end
     end
   end
@@ -54,16 +54,16 @@ describe Her::Model::NestedAttributes do
 
     context "when child does not yet exist" do
       it "creates an instance of the associated class" do
-        @user_with_data_through_nested_attributes.pet.should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes.pet.name.should == "Hasi"
+        expect(@user_with_data_through_nested_attributes.pet).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes.pet.name).to eq("Hasi")
       end
     end
 
     context "when child does exist" do
       it "updates the attributes of the associated object" do
         @user_with_data_through_nested_attributes.pet_attributes = { :name => "Rodriguez" }
-        @user_with_data_through_nested_attributes.pet.should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes.pet.name.should == "Rodriguez"
+        expect(@user_with_data_through_nested_attributes.pet).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes.pet.name).to eq("Rodriguez")
       end
     end
   end
@@ -87,11 +87,11 @@ describe Her::Model::NestedAttributes do
 
     context "when children do not yet exist" do
       it "creates an instance of the associated class" do
-        @user_with_data_through_nested_attributes.pets.length.should == 2
-        @user_with_data_through_nested_attributes.pets[0].should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes.pets[1].should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes.pets[0].name.should == "Hasi"
-        @user_with_data_through_nested_attributes.pets[1].name.should == "Rodriguez"
+        expect(@user_with_data_through_nested_attributes.pets.length).to eq(2)
+        expect(@user_with_data_through_nested_attributes.pets[0]).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes.pets[1]).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes.pets[0].name).to eq("Hasi")
+        expect(@user_with_data_through_nested_attributes.pets[1].name).to eq("Rodriguez")
       end
     end
   end
@@ -115,11 +115,11 @@ describe Her::Model::NestedAttributes do
 
     context "when children do not yet exist" do
       it "creates an instance of the associated class" do
-        @user_with_data_through_nested_attributes_as_hash.pets.length.should == 2
-        @user_with_data_through_nested_attributes_as_hash.pets[0].should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes_as_hash.pets[1].should be_a(Foo::Pet)
-        @user_with_data_through_nested_attributes_as_hash.pets[0].name.should == "Hasi"
-        @user_with_data_through_nested_attributes_as_hash.pets[1].name.should == "Rodriguez"
+        expect(@user_with_data_through_nested_attributes_as_hash.pets.length).to eq(2)
+        expect(@user_with_data_through_nested_attributes_as_hash.pets[0]).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes_as_hash.pets[1]).to be_a(Foo::Pet)
+        expect(@user_with_data_through_nested_attributes_as_hash.pets[0].name).to eq("Hasi")
+        expect(@user_with_data_through_nested_attributes_as_hash.pets[1].name).to eq("Rodriguez")
       end
     end
   end

--- a/spec/model/nested_attributes_spec.rb
+++ b/spec/model/nested_attributes_spec.rb
@@ -110,7 +110,7 @@ describe Her::Model::NestedAttributes do
 
       spawn_model "Foo::Pet"
 
-      @user_with_data_through_nested_attributes_as_hash = Foo::User.new name: "Test", pets_attributes: { '0' => { name: "Hasi" }, '1' => { name: "Rodriguez" }}
+      @user_with_data_through_nested_attributes_as_hash = Foo::User.new name: "Test", pets_attributes: { "0" => { name: "Hasi" }, "1" => { name: "Rodriguez" } }
     end
 
     context "when children do not yet exist" do
@@ -126,9 +126,9 @@ describe Her::Model::NestedAttributes do
 
   context "with an unknown association" do
     it "raises an error" do
-      expect {
+      expect do
         spawn_model("Foo::User") { accepts_nested_attributes_for :company }
-      }.to raise_error(Her::Errors::AssociationUnknownError, 'Unknown association name :company')
+      end.to raise_error(Her::Errors::AssociationUnknownError, "Unknown association name :company")
     end
   end
 end

--- a/spec/model/nested_attributes_spec.rb
+++ b/spec/model/nested_attributes_spec.rb
@@ -4,19 +4,19 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 describe Her::Model::NestedAttributes do
   context "with a belongs_to association" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
 
       spawn_model "Foo::User" do
-        belongs_to :company, :path => "/organizations/:id", :foreign_key => :organization_id
+        belongs_to :company, path: "/organizations/:id", foreign_key: :organization_id
         accepts_nested_attributes_for :company
       end
 
       spawn_model "Foo::Company"
 
-      @user_with_data_through_nested_attributes = Foo::User.new :name => "Test", :company_attributes => { :name => "Example Company" }
+      @user_with_data_through_nested_attributes = Foo::User.new name: "Test", company_attributes: { name: "Example Company" }
     end
 
     context "when child does not yet exist" do
@@ -28,7 +28,7 @@ describe Her::Model::NestedAttributes do
 
     context "when child does exist" do
       it "updates the attributes of the associated object" do
-        @user_with_data_through_nested_attributes.company_attributes = { :name => "Fünke's Company" }
+        @user_with_data_through_nested_attributes.company_attributes = { name: "Fünke's Company" }
         expect(@user_with_data_through_nested_attributes.company).to be_a(Foo::Company)
         expect(@user_with_data_through_nested_attributes.company.name).to eq("Fünke's Company")
       end
@@ -37,7 +37,7 @@ describe Her::Model::NestedAttributes do
 
   context "with a has_one association" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
@@ -49,7 +49,7 @@ describe Her::Model::NestedAttributes do
 
       spawn_model "Foo::Pet"
 
-      @user_with_data_through_nested_attributes = Foo::User.new :name => "Test", :pet_attributes => { :name => "Hasi" }
+      @user_with_data_through_nested_attributes = Foo::User.new name: "Test", pet_attributes: { name: "Hasi" }
     end
 
     context "when child does not yet exist" do
@@ -61,7 +61,7 @@ describe Her::Model::NestedAttributes do
 
     context "when child does exist" do
       it "updates the attributes of the associated object" do
-        @user_with_data_through_nested_attributes.pet_attributes = { :name => "Rodriguez" }
+        @user_with_data_through_nested_attributes.pet_attributes = { name: "Rodriguez" }
         expect(@user_with_data_through_nested_attributes.pet).to be_a(Foo::Pet)
         expect(@user_with_data_through_nested_attributes.pet.name).to eq("Rodriguez")
       end
@@ -70,7 +70,7 @@ describe Her::Model::NestedAttributes do
 
   context "with a has_many association" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
@@ -82,7 +82,7 @@ describe Her::Model::NestedAttributes do
 
       spawn_model "Foo::Pet"
 
-      @user_with_data_through_nested_attributes = Foo::User.new :name => "Test", :pets_attributes => [{ :name => "Hasi" }, { :name => "Rodriguez" }]
+      @user_with_data_through_nested_attributes = Foo::User.new name: "Test", pets_attributes: [{ name: "Hasi" }, { name: "Rodriguez" }]
     end
 
     context "when children do not yet exist" do
@@ -98,7 +98,7 @@ describe Her::Model::NestedAttributes do
 
   context "with a has_many association as a Hash" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
@@ -110,7 +110,7 @@ describe Her::Model::NestedAttributes do
 
       spawn_model "Foo::Pet"
 
-      @user_with_data_through_nested_attributes_as_hash = Foo::User.new :name => "Test", :pets_attributes => { '0' => { :name => "Hasi" }, '1' => { :name => "Rodriguez" }}
+      @user_with_data_through_nested_attributes_as_hash = Foo::User.new name: "Test", pets_attributes: { '0' => { name: "Hasi" }, '1' => { name: "Rodriguez" }}
     end
 
     context "when children do not yet exist" do

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -28,41 +28,41 @@ describe Her::Model::ORM do
 
     it "maps a single resource to a Ruby object" do
       @user = Foo::User.find(1)
-      @user.id.should == 1
-      @user.name.should == "Tobias Fünke"
+      expect(@user.id).to eq(1)
+      expect(@user.name).to eq("Tobias Fünke")
 
       @admin = Foo::AdminUser.find(1)
-      @admin.id.should == 1
-      @admin.name.should == "Tobias Fünke"
+      expect(@admin.id).to eq(1)
+      expect(@admin.name).to eq("Tobias Fünke")
     end
 
     it "maps a collection of resources to an array of Ruby objects" do
       @users = Foo::User.all
-      @users.length.should == 2
-      @users.first.name.should == "Tobias Fünke"
+      expect(@users.length).to eq(2)
+      expect(@users.first.name).to eq("Tobias Fünke")
 
       @users = Foo::AdminUser.all
-      @users.length.should == 2
-      @users.first.name.should == "Tobias Fünke"
+      expect(@users.length).to eq(2)
+      expect(@users.first.name).to eq("Tobias Fünke")
     end
 
     it "handles new resource" do
       @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-      @new_user.new?.should be_truthy
-      @new_user.new_record?.should be_truthy
-      @new_user.fullname.should == "Tobias Fünke"
+      expect(@new_user.new?).to be_truthy
+      expect(@new_user.new_record?).to be_truthy
+      expect(@new_user.fullname).to eq("Tobias Fünke")
 
       @existing_user = Foo::User.find(1)
-      @existing_user.new?.should be_falsey
-      @existing_user.new_record?.should be_falsey
+      expect(@existing_user.new?).to be_falsey
+      expect(@existing_user.new_record?).to be_falsey
     end
 
     it 'handles new resource with custom primary key' do
       @new_user = Foo::AdminUser.new(:fullname => 'Lindsay Fünke', :id => -1)
-      @new_user.should be_new
+      expect(@new_user).to be_new
 
       @existing_user = Foo::AdminUser.find(1)
-      @existing_user.should_not be_new
+      expect(@existing_user).not_to be_new
     end
   end
 
@@ -85,22 +85,22 @@ describe Her::Model::ORM do
 
     it "handles metadata on a collection" do
       @users = User.all
-      @users.metadata[:total_pages].should == 10
+      expect(@users.metadata[:total_pages]).to eq(10)
     end
 
     it "handles error data on a collection" do
       @users = User.all
-      @users.errors.length.should == 3
+      expect(@users.errors.length).to eq(3)
     end
 
     it "handles metadata on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.metadata[:foo].should == "bar"
+      expect(@user.metadata[:foo]).to eq("bar")
     end
 
     it "handles error data on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.response_errors.should == ["Yes", "Sir"]
+      expect(@user.response_errors).to eq(["Yes", "Sir"])
     end
   end
 
@@ -123,22 +123,22 @@ describe Her::Model::ORM do
 
     it "handles metadata on a collection" do
       @users = User.all
-      @users.metadata[:total_pages].should == 10
+      expect(@users.metadata[:total_pages]).to eq(10)
     end
 
     it "handles error data on a collection" do
       @users = User.all
-      @users.errors.length.should == 3
+      expect(@users.errors.length).to eq(3)
     end
 
     it "handles metadata on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.metadata[:foo].should == "bar"
+      expect(@user.metadata[:foo]).to eq("bar")
     end
 
     it "handles error data on a resource" do
       @user = User.create(:name => "George Michael Bluth")
-      @user.response_errors.should == ["Yes", "Sir"]
+      expect(@user.response_errors).to eq(["Yes", "Sir"])
     end
   end
 
@@ -171,7 +171,7 @@ describe Her::Model::ORM do
 
     it "handles custom setters" do
       @user = User.find(1)
-      @user.friends.should == "* Maeby\n* GOB\n* Anne"
+      expect(@user.friends).to eq("* Maeby\n* GOB\n* Anne")
       @user.instance_eval do
         @attributes[:friends] = ["Maeby", "GOB", "Anne"]
       end
@@ -180,7 +180,7 @@ describe Her::Model::ORM do
     it "handles custom getters" do
       @user = User.new
       @user.friends = "* George\n* Oscar\n* Lucille"
-      @user.friends.should == "* George\n* Oscar\n* Lucille"
+      expect(@user.friends).to eq("* George\n* Oscar\n* Lucille")
       @user.instance_eval do
         @attributes[:friends] = ["George", "Oscar", "Lucille"]
       end
@@ -210,58 +210,58 @@ describe Her::Model::ORM do
 
     it "handles finding by a single id" do
       @user = User.find(1)
-      @user.id.should == 1
+      expect(@user.id).to eq(1)
     end
 
     it "handles finding by multiple ids" do
       @users = User.find(1, 2)
-      @users.should be_kind_of(Array)
-      @users.length.should == 2
-      @users[0].id.should == 1
-      @users[1].id.should == 2
+      expect(@users).to be_kind_of(Array)
+      expect(@users.length).to eq(2)
+      expect(@users[0].id).to eq(1)
+      expect(@users[1].id).to eq(2)
     end
 
     it "handles finding by an array of ids" do
       @users = User.find([1, 2])
-      @users.should be_kind_of(Array)
-      @users.length.should == 2
-      @users[0].id.should == 1
-      @users[1].id.should == 2
+      expect(@users).to be_kind_of(Array)
+      expect(@users.length).to eq(2)
+      expect(@users[0].id).to eq(1)
+      expect(@users[1].id).to eq(2)
     end
 
     it "handles finding by an array of ids of length 1" do
       @users = User.find([1])
-      @users.should be_kind_of(Array)
-      @users.length.should == 1
-      @users[0].id.should == 1
+      expect(@users).to be_kind_of(Array)
+      expect(@users.length).to eq(1)
+      expect(@users[0].id).to eq(1)
     end
 
     it "handles finding by an array id param of length 2" do
       @users = User.find(id: [1, 2])
-      @users.should be_kind_of(Array)
-      @users.length.should == 2
-      @users[0].id.should == 1
-      @users[1].id.should == 2
+      expect(@users).to be_kind_of(Array)
+      expect(@users.length).to eq(2)
+      expect(@users[0].id).to eq(1)
+      expect(@users[1].id).to eq(2)
     end
 
     it 'handles finding with id parameter as an array' do
       @users = User.where(id: [1, 2])
-      @users.should be_kind_of(Array)
-      @users.length.should == 2
-      @users[0].id.should == 1
-      @users[1].id.should == 2
+      expect(@users).to be_kind_of(Array)
+      expect(@users.length).to eq(2)
+      expect(@users[0].id).to eq(1)
+      expect(@users[1].id).to eq(2)
     end
 
     it "handles finding with other parameters" do
       @users = User.where(:age => 42, :foo => "bar").all
-      @users.should be_kind_of(Array)
-      @users.first.id.should == 3
+      expect(@users).to be_kind_of(Array)
+      expect(@users.first.id).to eq(3)
     end
 
     it "handles finding with other parameters and scoped" do
       @users = User.scoped
-      @users.where(:age => 42).should be_all { |u| u.age == 42 }
-      @users.where(:age => 40).should be_all { |u| u.age == 40 }
+      expect(@users.where(:age => 42)).to be_all { |u| u.age == 42 }
+      expect(@users.where(:age => 40)).to be_all { |u| u.age == 40 }
     end
   end
 
@@ -272,10 +272,10 @@ describe Her::Model::ORM do
       end
 
       it "builds a new resource without requesting it" do
-        Foo::User.should_not_receive(:request)
+        expect(Foo::User).not_to receive(:request)
         @new_user = Foo::User.build(:fullname => "Tobias Fünke")
-        @new_user.new?.should be_truthy
-        @new_user.fullname.should == "Tobias Fünke"
+        expect(@new_user.new?).to be_truthy
+        expect(@new_user.fullname).to eq("Tobias Fünke")
       end
     end
 
@@ -293,11 +293,11 @@ describe Her::Model::ORM do
       end
 
       it "requests a new resource" do
-        Foo::User.should_receive(:request).once.and_call_original
+        expect(Foo::User).to receive(:request).once.and_call_original
         @new_user = Foo::User.build(:fullname => "Tobias Fünke")
-        @new_user.new?.should be_truthy
-        @new_user.fullname.should == "Tobias Fünke"
-        @new_user.email.should == "tobias@bluthcompany.com"
+        expect(@new_user.new?).to be_truthy
+        expect(@new_user.fullname).to eq("Tobias Fünke")
+        expect(@new_user.email).to eq("tobias@bluthcompany.com")
       end
     end
   end
@@ -319,26 +319,26 @@ describe Her::Model::ORM do
 
     it "handle one-line resource creation" do
       @user = Foo::User.create(:fullname => "Tobias Fünke", :email => "tobias@bluth.com")
-      @user.id.should == 1
-      @user.fullname.should == "Tobias Fünke"
-      @user.email.should == "tobias@bluth.com"
+      expect(@user.id).to eq(1)
+      expect(@user.fullname).to eq("Tobias Fünke")
+      expect(@user.email).to eq("tobias@bluth.com")
     end
 
     it "handle resource creation through Model.new + #save" do
       @user = Foo::User.new(:fullname => "Tobias Fünke")
-      @user.save.should be_truthy
-      @user.fullname.should == "Tobias Fünke"
+      expect(@user.save).to be_truthy
+      expect(@user.fullname).to eq("Tobias Fünke")
     end
 
     it "handle resource creation through Model.new + #save!" do
       @user = Foo::User.new(:fullname => "Tobias Fünke")
-      @user.save!.should be_truthy
-      @user.fullname.should == "Tobias Fünke"
+      expect(@user.save!).to be_truthy
+      expect(@user.fullname).to eq("Tobias Fünke")
     end
 
     it "returns false when #save gets errors" do
       @company = Foo::Company.new
-      @company.save.should be_falsey
+      expect(@company.save).to be_falsey
     end
 
     it "raises ResourceInvalid when #save! gets errors" do
@@ -348,8 +348,8 @@ describe Her::Model::ORM do
 
     it "don't overwrite data if response is empty" do
       @company = Foo::Company.new(:name => 'Company Inc.')
-      @company.save.should be_falsey
-      @company.name.should == "Company Inc."
+      expect(@company.save).to be_falsey
+      expect(@company.name).to eq("Company Inc.")
     end
   end
 
@@ -369,21 +369,21 @@ describe Her::Model::ORM do
 
     it "handle resource data update without saving it" do
       @user = Foo::User.find(1)
-      @user.fullname.should == "Tobias Fünke"
+      expect(@user.fullname).to eq("Tobias Fünke")
       @user.fullname = "Kittie Sanchez"
-      @user.fullname.should == "Kittie Sanchez"
+      expect(@user.fullname).to eq("Kittie Sanchez")
     end
 
     it "handle resource update through the .update class method" do
       @user = Foo::User.save_existing(1, { :fullname => "Lindsay Fünke" })
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
 
     it "handle resource update through #save on an existing resource" do
       @user = Foo::User.find(1)
       @user.fullname = "Lindsay Fünke"
       @user.save
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
   end
 
@@ -403,15 +403,15 @@ describe Her::Model::ORM do
 
     it "handle resource deletion through the .destroy class method" do
       @user = Foo::User.destroy_existing(1)
-      @user.active.should be_falsey
-      @user.should be_destroyed
+      expect(@user.active).to be_falsey
+      expect(@user).to be_destroyed
     end
 
     it "handle resource deletion through #destroy on an existing resource" do
       @user = Foo::User.find(1)
       @user.destroy
-      @user.active.should be_falsey
-      @user.should be_destroyed
+      expect(@user.active).to be_falsey
+      expect(@user).to be_destroyed
     end
 
     context "with params" do
@@ -428,14 +428,14 @@ describe Her::Model::ORM do
       it "handle resource deletion through the .destroy class method" do
         @user = Foo::User.destroy_existing(1, delete_type: 'soft')
         expect(@user.active).to be_falsey
-        @user.should be_destroyed
+        expect(@user).to be_destroyed
       end
 
       it "handle resource deletion through #destroy on an existing resource" do
         @user = Foo::User.find(1)
         @user.destroy(delete_type: 'soft')
         expect(@user.active).to be_falsey
-        @user.should be_destroyed
+        expect(@user).to be_destroyed
       end
     end
   end
@@ -462,8 +462,8 @@ describe Her::Model::ORM do
       context 'for top-level class' do
         it 'uses the custom method (PUT) instead of default method (POST)' do
           user = Foo::User.new(:fullname => 'Tobias Fünke')
-          user.should be_new
-          user.save.should be_truthy
+          expect(user).to be_new
+          expect(user.save).to be_truthy
         end
       end
 
@@ -475,8 +475,8 @@ describe Her::Model::ORM do
 
         it 'uses the custom method (PUT) instead of default method (POST)' do
           user = User.new(:fullname => 'Tobias Fünke')
-          user.should be_new
-          user.save.should be_truthy
+          expect(user).to be_new
+          expect(user.save).to be_truthy
         end
       end
     end
@@ -496,10 +496,10 @@ describe Her::Model::ORM do
 
       it 'uses the custom method (POST) instead of default method (PUT)' do
         user = Foo::User.find(1)
-        user.fullname.should eq 'Lindsay Fünke'
+        expect(user.fullname).to eq 'Lindsay Fünke'
         user.fullname = 'Toby Fünke'
         user.save
-        user.fullname.should eq 'Tobias Fünke'
+        expect(user.fullname).to eq 'Tobias Fünke'
       end
     end
   end

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -9,10 +9,10 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
-          stub.get("/users") { |_env| [200, {}, [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }].to_json] }
-          stub.get("/admin_users") { |_env| [200, {}, [{ admin_id: 1, name: "Tobias Fünke" }, { admin_id: 2, name: "Lindsay Fünke" }].to_json] }
-          stub.get("/admin_users/1") { |_env| [200, {}, { admin_id: 1, name: "Tobias Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+          stub.get("/users") { [200, {}, [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }].to_json] }
+          stub.get("/admin_users") { [200, {}, [{ admin_id: 1, name: "Tobias Fünke" }, { admin_id: 2, name: "Lindsay Fünke" }].to_json] }
+          stub.get("/admin_users/1") { [200, {}, { admin_id: 1, name: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -73,8 +73,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::SecondLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |_env| [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: %w(Oh My God) }.to_json] }
-          stub.post("/users") { |_env| [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: %w(Yes Sir) }.to_json] }
+          stub.get("/users") { [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: %w(Oh My God) }.to_json] }
+          stub.post("/users") { [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: %w(Yes Sir) }.to_json] }
         end
       end
 
@@ -111,8 +111,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::SecondLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |_env| [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: %w(Oh My God) }.to_json] }
-          stub.post("/users") { |_env| [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: %w(Yes Sir) }.to_json] }
+          stub.get("/users") { [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: %w(Oh My God) }.to_json] }
+          stub.post("/users") { [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: %w(Yes Sir) }.to_json] }
         end
       end
 
@@ -149,8 +149,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, friends: %w(Maeby GOB Anne) }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { id: 1 }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, friends: %w(Maeby GOB Anne) }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 1 }.to_json] }
         end
       end
 
@@ -194,12 +194,12 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, age: 42 }.to_json] }
-          stub.get("/users/2") { |_env| [200, {}, { id: 2, age: 34 }.to_json] }
-          stub.get("/users?id[]=1&id[]=2") { |_env| [200, {}, [{ id: 1, age: 42 }, { id: 2, age: 34 }].to_json] }
-          stub.get("/users?age=42&foo=bar") { |_env| [200, {}, [{ id: 3, age: 42 }].to_json] }
-          stub.get("/users?age=42") { |_env| [200, {}, [{ id: 1, age: 42 }].to_json] }
-          stub.get("/users?age=40") { |_env| [200, {}, [{ id: 1, age: 40 }].to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, age: 42 }.to_json] }
+          stub.get("/users/2") { [200, {}, { id: 2, age: 34 }.to_json] }
+          stub.get("/users?id[]=1&id[]=2") { [200, {}, [{ id: 1, age: 42 }, { id: 2, age: 34 }].to_json] }
+          stub.get("/users?age=42&foo=bar") { [200, {}, [{ id: 3, age: 42 }].to_json] }
+          stub.get("/users?age=42") { [200, {}, [{ id: 1, age: 42 }].to_json] }
+          stub.get("/users?age=40") { [200, {}, [{ id: 1, age: 40 }].to_json] }
         end
       end
 
@@ -309,7 +309,7 @@ describe Her::Model::ORM do
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
           stub.post("/users") { |env| [200, {}, { id: 1, fullname: Faraday::Utils.parse_query(env[:body])["fullname"], email: Faraday::Utils.parse_query(env[:body])["email"] }.to_json] }
-          stub.post("/companies") { |_env| [200, {}, { errors: ["name is required"] }.to_json] }
+          stub.post("/companies") { [200, {}, { errors: ["name is required"] }.to_json] }
         end
       end
 
@@ -359,8 +359,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
-          stub.put("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.put("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
         end
       end
 
@@ -393,8 +393,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", active: true }.to_json] }
-          stub.delete("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", active: true }.to_json] }
+          stub.delete("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
         end
       end
 
@@ -420,7 +420,7 @@ describe Her::Model::ORM do
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.delete("/users/1?delete_type=soft") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
+            stub.delete("/users/1?delete_type=soft") { [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
           end
         end
       end
@@ -451,7 +451,7 @@ describe Her::Model::ORM do
     context "create" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.put("/users") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.put("/users") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
         spawn_model "Foo::User" do
           attributes :fullname, :email
@@ -484,8 +484,8 @@ describe Her::Model::ORM do
     context "update" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.get("/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
-          stub.post("/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.post("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
         end
 
         spawn_model "Foo::User" do

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -427,14 +427,14 @@ describe Her::Model::ORM do
 
       it "handle resource deletion through the .destroy class method" do
         @user = Foo::User.destroy_existing(1, delete_type: 'soft')
-        @user.active.should be_false
+        expect(@user.active).to be_falsey
         @user.should be_destroyed
       end
 
       it "handle resource deletion through #destroy on an existing resource" do
         @user = Foo::User.find(1)
         @user.destroy(delete_type: 'soft')
-        @user.active.should be_false
+        expect(@user.active).to be_falsey
         @user.should be_destroyed
       end
     end

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -5,14 +5,14 @@ describe Her::Model::ORM do
   context "mapping data to Ruby objects" do
     before do
       api = Her::API.new
-      api.setup :url => "https://api.example.com" do |builder|
+      api.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json] }
-          stub.get("/users") { |env| [200, {}, [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }].to_json] }
-          stub.get("/admin_users") { |env| [200, {}, [{ :admin_id => 1, :name => "Tobias Fünke" }, { :admin_id => 2, :name => "Lindsay Fünke" }].to_json] }
-          stub.get("/admin_users/1") { |env| [200, {}, { :admin_id => 1, :name => "Tobias Fünke" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+          stub.get("/users") { |env| [200, {}, [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }].to_json] }
+          stub.get("/admin_users") { |env| [200, {}, [{ admin_id: 1, name: "Tobias Fünke" }, { admin_id: 2, name: "Lindsay Fünke" }].to_json] }
+          stub.get("/admin_users/1") { |env| [200, {}, { admin_id: 1, name: "Tobias Fünke" }.to_json] }
         end
       end
 
@@ -47,7 +47,7 @@ describe Her::Model::ORM do
     end
 
     it "handles new resource" do
-      @new_user = Foo::User.new(:fullname => "Tobias Fünke")
+      @new_user = Foo::User.new(fullname: "Tobias Fünke")
       expect(@new_user.new?).to be_truthy
       expect(@new_user.new_record?).to be_truthy
       expect(@new_user.fullname).to eq("Tobias Fünke")
@@ -58,7 +58,7 @@ describe Her::Model::ORM do
     end
 
     it 'handles new resource with custom primary key' do
-      @new_user = Foo::AdminUser.new(:fullname => 'Lindsay Fünke', :id => -1)
+      @new_user = Foo::AdminUser.new(fullname: 'Lindsay Fünke', id: -1)
       expect(@new_user).to be_new
 
       @existing_user = Foo::AdminUser.find(1)
@@ -69,12 +69,12 @@ describe Her::Model::ORM do
   context "mapping data, metadata and error data to Ruby objects" do
     before do
       api = Her::API.new
-      api.setup :url => "https://api.example.com" do |builder|
+      api.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::SecondLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {}, { :data => [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }], :metadata => { :total_pages => 10, :next_page => 2 }, :errors => ["Oh", "My", "God"] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :data => { :name => "George Michael Bluth" }, :metadata => { :foo => "bar" }, :errors => ["Yes", "Sir"] }.to_json] }
+          stub.get("/users") { |env| [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: ["Oh", "My", "God"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: ["Yes", "Sir"] }.to_json] }
         end
       end
 
@@ -94,12 +94,12 @@ describe Her::Model::ORM do
     end
 
     it "handles metadata on a resource" do
-      @user = User.create(:name => "George Michael Bluth")
+      @user = User.create(name: "George Michael Bluth")
       expect(@user.metadata[:foo]).to eq("bar")
     end
 
     it "handles error data on a resource" do
-      @user = User.create(:name => "George Michael Bluth")
+      @user = User.create(name: "George Michael Bluth")
       expect(@user.response_errors).to eq(["Yes", "Sir"])
     end
   end
@@ -107,12 +107,12 @@ describe Her::Model::ORM do
   context "mapping data, metadata and error data in string keys to Ruby objects" do
     before do
       api = Her::API.new
-      api.setup :url => "https://api.example.com" do |builder|
+      api.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::SecondLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {}, { 'data' => [{ :id => 1, :name => "Tobias Fünke" }, { :id => 2, :name => "Lindsay Fünke" }], 'metadata' => { :total_pages => 10, :next_page => 2 }, 'errors' => ["Oh", "My", "God"] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { 'data' => { :name => "George Michael Bluth" }, 'metadata' => { :foo => "bar" }, 'errors' => ["Yes", "Sir"] }.to_json] }
+          stub.get("/users") { |env| [200, {}, { data: [{ id: 1, name: "Tobias Fünke" }, { id: 2, name: "Lindsay Fünke" }], metadata: { total_pages: 10, next_page: 2 }, errors: ["Oh", "My", "God"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { data: { name: "George Michael Bluth" }, metadata: { foo: "bar" }, errors: ["Yes", "Sir"] }.to_json] }
         end
       end
 
@@ -132,12 +132,12 @@ describe Her::Model::ORM do
     end
 
     it "handles metadata on a resource" do
-      @user = User.create(:name => "George Michael Bluth")
+      @user = User.create(name: "George Michael Bluth")
       expect(@user.metadata[:foo]).to eq("bar")
     end
 
     it "handles error data on a resource" do
-      @user = User.create(:name => "George Michael Bluth")
+      @user = User.create(name: "George Michael Bluth")
       expect(@user.response_errors).to eq(["Yes", "Sir"])
     end
   end
@@ -145,12 +145,12 @@ describe Her::Model::ORM do
   context "defining custom getters and setters" do
     before do
       api = Her::API.new
-      api.setup :url => "https://api.example.com" do |builder|
+      api.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :friends => ["Maeby", "GOB", "Anne"] }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 1 }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, friends: ["Maeby", "GOB", "Anne"] }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 1 }.to_json] }
         end
       end
 
@@ -190,16 +190,16 @@ describe Her::Model::ORM do
   context "finding resources" do
     before do
       api = Her::API.new
-      api.setup :url => "https://api.example.com" do |builder|
+      api.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :age => 42 }.to_json] }
-          stub.get("/users/2") { |env| [200, {}, { :id => 2, :age => 34 }.to_json] }
-          stub.get("/users?id[]=1&id[]=2") { |env| [200, {}, [{ :id => 1, :age => 42 }, { :id => 2, :age => 34 }].to_json] }
-          stub.get("/users?age=42&foo=bar") { |env| [200, {}, [{ :id => 3, :age => 42 }].to_json] }
-          stub.get("/users?age=42") { |env| [200, {}, [{ :id => 1, :age => 42 }].to_json] }
-          stub.get("/users?age=40") { |env| [200, {}, [{ :id => 1, :age => 40 }].to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, age: 42 }.to_json] }
+          stub.get("/users/2") { |env| [200, {}, { id: 2, age: 34 }.to_json] }
+          stub.get("/users?id[]=1&id[]=2") { |env| [200, {}, [{ id: 1, age: 42 }, { id: 2, age: 34 }].to_json] }
+          stub.get("/users?age=42&foo=bar") { |env| [200, {}, [{ id: 3, age: 42 }].to_json] }
+          stub.get("/users?age=42") { |env| [200, {}, [{ id: 1, age: 42 }].to_json] }
+          stub.get("/users?age=40") { |env| [200, {}, [{ id: 1, age: 40 }].to_json] }
         end
       end
 
@@ -253,15 +253,15 @@ describe Her::Model::ORM do
     end
 
     it "handles finding with other parameters" do
-      @users = User.where(:age => 42, :foo => "bar").all
+      @users = User.where(age: 42, foo: "bar").all
       expect(@users).to be_kind_of(Array)
       expect(@users.first.id).to eq(3)
     end
 
     it "handles finding with other parameters and scoped" do
       @users = User.scoped
-      expect(@users.where(:age => 42)).to be_all { |u| u.age == 42 }
-      expect(@users.where(:age => 40)).to be_all { |u| u.age == 40 }
+      expect(@users.where(age: 42)).to be_all { |u| u.age == 42 }
+      expect(@users.where(age: 40)).to be_all { |u| u.age == 40 }
     end
   end
 
@@ -273,7 +273,7 @@ describe Her::Model::ORM do
 
       it "builds a new resource without requesting it" do
         expect(Foo::User).not_to receive(:request)
-        @new_user = Foo::User.build(:fullname => "Tobias Fünke")
+        @new_user = Foo::User.build(fullname: "Tobias Fünke")
         expect(@new_user.new?).to be_truthy
         expect(@new_user.fullname).to eq("Tobias Fünke")
       end
@@ -281,11 +281,11 @@ describe Her::Model::ORM do
 
     context "when request_new_object_on_build is set" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/new") { |env| ok! :id => nil, :fullname => params(env)[:fullname], :email => "tobias@bluthcompany.com" }
+            stub.get("/users/new") { |env| ok! id: nil, fullname: params(env)[:fullname], email: "tobias@bluthcompany.com" }
           end
         end
 
@@ -294,7 +294,7 @@ describe Her::Model::ORM do
 
       it "requests a new resource" do
         expect(Foo::User).to receive(:request).once.and_call_original
-        @new_user = Foo::User.build(:fullname => "Tobias Fünke")
+        @new_user = Foo::User.build(fullname: "Tobias Fünke")
         expect(@new_user.new?).to be_truthy
         expect(@new_user.fullname).to eq("Tobias Fünke")
         expect(@new_user.email).to eq("tobias@bluthcompany.com")
@@ -304,12 +304,12 @@ describe Her::Model::ORM do
 
   context "creating resources" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :id => 1, :fullname => Faraday::Utils.parse_query(env[:body])['fullname'], :email => Faraday::Utils.parse_query(env[:body])['email'] }.to_json] }
-          stub.post("/companies") { |env| [200, {}, { :errors => ["name is required"] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { id: 1, fullname: Faraday::Utils.parse_query(env[:body])['fullname'], email: Faraday::Utils.parse_query(env[:body])['email'] }.to_json] }
+          stub.post("/companies") { |env| [200, {}, { errors: ["name is required"] }.to_json] }
         end
       end
 
@@ -318,20 +318,20 @@ describe Her::Model::ORM do
     end
 
     it "handle one-line resource creation" do
-      @user = Foo::User.create(:fullname => "Tobias Fünke", :email => "tobias@bluth.com")
+      @user = Foo::User.create(fullname: "Tobias Fünke", email: "tobias@bluth.com")
       expect(@user.id).to eq(1)
       expect(@user.fullname).to eq("Tobias Fünke")
       expect(@user.email).to eq("tobias@bluth.com")
     end
 
     it "handle resource creation through Model.new + #save" do
-      @user = Foo::User.new(:fullname => "Tobias Fünke")
+      @user = Foo::User.new(fullname: "Tobias Fünke")
       expect(@user.save).to be_truthy
       expect(@user.fullname).to eq("Tobias Fünke")
     end
 
     it "handle resource creation through Model.new + #save!" do
-      @user = Foo::User.new(:fullname => "Tobias Fünke")
+      @user = Foo::User.new(fullname: "Tobias Fünke")
       expect(@user.save!).to be_truthy
       expect(@user.fullname).to eq("Tobias Fünke")
     end
@@ -347,7 +347,7 @@ describe Her::Model::ORM do
     end
 
     it "don't overwrite data if response is empty" do
-      @company = Foo::Company.new(:name => 'Company Inc.')
+      @company = Foo::Company.new(name: 'Company Inc.')
       expect(@company.save).to be_falsey
       expect(@company.name).to eq("Company Inc.")
     end
@@ -355,12 +355,12 @@ describe Her::Model::ORM do
 
   context "updating resources" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke" }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
         end
       end
 
@@ -375,7 +375,7 @@ describe Her::Model::ORM do
     end
 
     it "handle resource update through the .update class method" do
-      @user = Foo::User.save_existing(1, { :fullname => "Lindsay Fünke" })
+      @user = Foo::User.save_existing(1, { fullname: "Lindsay Fünke" })
       expect(@user.fullname).to eq("Lindsay Fünke")
     end
 
@@ -389,12 +389,12 @@ describe Her::Model::ORM do
 
   context "deleting resources" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :active => true }.to_json] }
-          stub.delete("/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke", :active => false }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", active: true }.to_json] }
+          stub.delete("/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
         end
       end
 
@@ -416,11 +416,11 @@ describe Her::Model::ORM do
 
     context "with params" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.delete("/users/1?delete_type=soft") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke", :active => false }.to_json] }
+            stub.delete("/users/1?delete_type=soft") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
           end
         end
       end
@@ -442,7 +442,7 @@ describe Her::Model::ORM do
 
   context 'customizing HTTP methods' do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
@@ -451,7 +451,7 @@ describe Her::Model::ORM do
     context 'create' do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.put('/users') { |env| [200, {}, { :id => 1, :fullname => 'Tobias Fünke' }.to_json] }
+          stub.put('/users') { |env| [200, {}, { id: 1, fullname: 'Tobias Fünke' }.to_json] }
         end
         spawn_model 'Foo::User' do
           attributes :fullname, :email
@@ -461,7 +461,7 @@ describe Her::Model::ORM do
 
       context 'for top-level class' do
         it 'uses the custom method (PUT) instead of default method (POST)' do
-          user = Foo::User.new(:fullname => 'Tobias Fünke')
+          user = Foo::User.new(fullname: 'Tobias Fünke')
           expect(user).to be_new
           expect(user.save).to be_truthy
         end
@@ -474,7 +474,7 @@ describe Her::Model::ORM do
         end
 
         it 'uses the custom method (PUT) instead of default method (POST)' do
-          user = User.new(:fullname => 'Tobias Fünke')
+          user = User.new(fullname: 'Tobias Fünke')
           expect(user).to be_new
           expect(user.save).to be_truthy
         end
@@ -484,8 +484,8 @@ describe Her::Model::ORM do
     context 'update' do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.get('/users/1') { |env| [200, {}, { :id => 1, :fullname => 'Lindsay Fünke' }.to_json] }
-          stub.post('/users/1') { |env| [200, {}, { :id => 1, :fullname => 'Tobias Fünke' }.to_json] }
+          stub.get('/users/1') { |env| [200, {}, { id: 1, fullname: 'Lindsay Fünke' }.to_json] }
+          stub.post('/users/1') { |env| [200, {}, { id: 1, fullname: 'Tobias Fünke' }.to_json] }
         end
 
         spawn_model 'Foo::User' do

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -26,12 +26,12 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        @new_user.to_params.should == { :user => { :fullname => "Tobias Fünke" } }
+        expect(@new_user.to_params).to eq({ :user => { :fullname => "Tobias Fünke" } })
       end
 
       it "wraps params in the element name in `.create`" do
         @new_user = Foo::User.admins(:fullname => "Tobias Fünke")
-        @new_user.fullname.should == "Tobias Fünke"
+        expect(@new_user.fullname).to eq("Tobias Fünke")
       end
     end
 
@@ -45,7 +45,7 @@ describe Her::Model::Parse do
 
       it "wraps params in the specified value" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        @new_user.to_params.should == { :person => { :fullname => "Tobias Fünke" } }
+        expect(@new_user.to_params).to eq({ :person => { :fullname => "Tobias Fünke" } })
       end
     end
 
@@ -59,7 +59,7 @@ describe Her::Model::Parse do
 
       it "wraps params with the class name" do
         @new_user = User.new(:fullname => "Tobias Fünke")
-        @new_user.to_params.should == { :user => { :fullname => "Tobias Fünke" } }
+        expect(@new_user.to_params).to eq({ :user => { :fullname => "Tobias Fünke" } })
       end
     end
   end
@@ -90,29 +90,29 @@ describe Her::Model::Parse do
 
       it "parse the data from the JSON root element after .create" do
         @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
-        @new_user.fullname.should == "Lindsay Fünke"
+        expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after an arbitrary HTTP request" do
         @new_user = Foo::User.admins
-        @new_user.first.fullname.should == "Lindsay Fünke"
+        expect(@new_user.first.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .all" do
         @users = Foo::User.all
-        @users.first.fullname.should == "Lindsay Fünke"
+        expect(@users.first.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .find" do
         @user = Foo::User.find(1)
-        @user.fullname.should == "Lindsay Fünke"
+        expect(@user.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .save" do
         @user = Foo::User.find(1)
         @user.fullname = "Tobias Fünke"
         @user.save
-        @user.fullname.should == "Tobias Fünke Jr."
+        expect(@user.fullname).to eq("Tobias Fünke Jr.")
       end
     end
 
@@ -127,7 +127,7 @@ describe Her::Model::Parse do
 
       it "parse the data with the symbol" do
         @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
-        @new_user.fullname.should == "Lindsay Fünke"
+        expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
     end
 
@@ -148,12 +148,12 @@ describe Her::Model::Parse do
 
       it "parse the data with the symbol" do
         @new_user = User.create(:fullname => "Lindsay Fünke")
-        @new_user.fullname.should == "Lindsay Fünke"
+        expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
       it "parses the collection of data" do
         @users = User.all
-        @users.first.fullname.should == "Lindsay Fünke"
+        expect(@users.first.fullname).to eq("Lindsay Fünke")
       end
     end
 
@@ -175,29 +175,29 @@ describe Her::Model::Parse do
 
       it "parse the data from the JSON root element after .create" do
         @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
-        @new_user.fullname.should == "Lindsay Fünke"
+        expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after an arbitrary HTTP request" do
         @users = Foo::User.admins
-        @users.first.fullname.should == "Lindsay Fünke"
+        expect(@users.first.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .all" do
         @users = Foo::User.all
-        @users.first.fullname.should == "Lindsay Fünke"
+        expect(@users.first.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .find" do
         @user = Foo::User.find(1)
-        @user.fullname.should == "Lindsay Fünke"
+        expect(@user.fullname).to eq("Lindsay Fünke")
       end
 
       it "parse the data from the JSON root element after .save" do
         @user = Foo::User.find(1)
         @user.fullname = "Tobias Fünke"
         @user.save
-        @user.fullname.should == "Tobias Fünke Jr."
+        expect(@user.fullname).to eq("Tobias Fünke Jr.")
       end
     end
   end
@@ -221,13 +221,13 @@ describe Her::Model::Parse do
 
     it "changes the request parameters for one-line resource creation" do
       @user = Foo::User.create(:fullname => "Tobias Fünke")
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
 
     it "changes the request parameters for Model.new + #save" do
       @user = Foo::User.new(:fullname => "Tobias Fünke")
       @user.save
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
   end
 
@@ -254,36 +254,36 @@ describe Her::Model::Parse do
 
     it "parse the data from the JSON root element after .create" do
       @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
-      @new_user.fullname.should == "Lindsay Fünke"
+      expect(@new_user.fullname).to eq("Lindsay Fünke")
     end
 
     it "parse the data from the JSON root element after an arbitrary HTTP request" do
       @new_user = Foo::User.admins
-      @new_user.first.fullname.should == "Lindsay Fünke"
+      expect(@new_user.first.fullname).to eq("Lindsay Fünke")
     end
 
     it "parse the data from the JSON root element after .all" do
       @users = Foo::User.all
-      @users.first.fullname.should == "Lindsay Fünke"
+      expect(@users.first.fullname).to eq("Lindsay Fünke")
     end
 
     it "parse the data from the JSON root element after .find" do
       @user = Foo::User.find(1)
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
 
     it "parse the data from the JSON root element after .save" do
       @user = Foo::User.find(1)
       @user.fullname = "Tobias Fünke"
       @user.save
-      @user.fullname.should == "Tobias Fünke Jr."
+      expect(@user.fullname).to eq("Tobias Fünke Jr.")
     end
 
     it "parse the data from the JSON root element after new/save" do
       @user = Foo::User.new
       @user.fullname = "Lindsay Fünke (before save)"
       @user.save
-      @user.fullname.should == "Lindsay Fünke"
+      expect(@user.fullname).to eq("Lindsay Fünke")
     end
   end
 
@@ -310,12 +310,12 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        @new_user.to_params.should == { :users => [{ :fullname => "Tobias Fünke" }] }
+        expect(@new_user.to_params).to eq({ :users => [{ :fullname => "Tobias Fünke" }] })
       end
 
       it "wraps params in the element name in `.where`" do
         @new_user = Foo::User.where(:fullname => "Tobias Fünke").build
-        @new_user.fullname.should == "Tobias Fünke"
+        expect(@new_user.fullname).to eq("Tobias Fünke")
       end
     end
   end

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -4,14 +4,14 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 describe Her::Model::Parse do
   context "when include_root_in_json is set" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.post("/users") { |env| [200, {}, { :user => { :id => 1, :fullname => params(env)[:user][:fullname] } }.to_json] }
-        stub.post("/users/admins") { |env| [200, {}, { :user => { :id => 1, :fullname => params(env)[:user][:fullname] } }.to_json] }
+        stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: params(env)[:user][:fullname] } }.to_json] }
+        stub.post("/users/admins") { |env| [200, {}, { user: { id: 1, fullname: params(env)[:user][:fullname] } }.to_json] }
       end
     end
 
@@ -25,12 +25,12 @@ describe Her::Model::Parse do
       end
 
       it "wraps params in the element name in `to_params`" do
-        @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ :user => { :fullname => "Tobias Fünke" } })
+        @new_user = Foo::User.new(fullname: "Tobias Fünke")
+        expect(@new_user.to_params).to eq({ user: { fullname: "Tobias Fünke" } })
       end
 
       it "wraps params in the element name in `.create`" do
-        @new_user = Foo::User.admins(:fullname => "Tobias Fünke")
+        @new_user = Foo::User.admins(fullname: "Tobias Fünke")
         expect(@new_user.fullname).to eq("Tobias Fünke")
       end
     end
@@ -44,8 +44,8 @@ describe Her::Model::Parse do
       end
 
       it "wraps params in the specified value" do
-        @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ :person => { :fullname => "Tobias Fünke" } })
+        @new_user = Foo::User.new(fullname: "Tobias Fünke")
+        expect(@new_user.to_params).to eq({ person: { fullname: "Tobias Fünke" } })
       end
     end
 
@@ -58,15 +58,15 @@ describe Her::Model::Parse do
       end
 
       it "wraps params with the class name" do
-        @new_user = User.new(:fullname => "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ :user => { :fullname => "Tobias Fünke" } })
+        @new_user = User.new(fullname: "Tobias Fünke")
+        expect(@new_user.to_params).to eq({ user: { fullname: "Tobias Fünke" } })
       end
     end
   end
 
   context "when parse_root_in_json is set" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
@@ -75,11 +75,11 @@ describe Her::Model::Parse do
     context "to true" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, [{ :user => { :id => 1, :fullname => "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/admins") { |env| [200, {}, [{ :user => { :id => 1, :fullname => "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/admins") { |env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
@@ -89,7 +89,7 @@ describe Her::Model::Parse do
       end
 
       it "parse the data from the JSON root element after .create" do
-        @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
+        @new_user = Foo::User.create(fullname: "Lindsay Fünke")
         expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
@@ -119,14 +119,14 @@ describe Her::Model::Parse do
     context "to a symbol" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :person => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
+          stub.post("/users") { |env| [200, {}, { person: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
         end
 
         spawn_model("Foo::User") { parse_root_in_json :person }
       end
 
       it "parse the data with the symbol" do
-        @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
+        @new_user = Foo::User.create(fullname: "Lindsay Fünke")
         expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
     end
@@ -134,8 +134,8 @@ describe Her::Model::Parse do
     context "in the parent class" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, { :users => [ { :id => 1, :fullname => "Lindsay Fünke" } ] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
         end
 
         spawn_model("Foo::Model") { parse_root_in_json true, format: :active_model_serializers }
@@ -147,7 +147,7 @@ describe Her::Model::Parse do
       end
 
       it "parse the data with the symbol" do
-        @new_user = User.create(:fullname => "Lindsay Fünke")
+        @new_user = User.create(fullname: "Lindsay Fünke")
         expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
@@ -157,24 +157,24 @@ describe Her::Model::Parse do
       end
     end
 
-    context "to true with :format => :active_model_serializers" do
+    context "to true with format: :active_model_serializers" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, { :users => [ { :id => 1, :fullname => "Lindsay Fünke" } ] }.to_json] }
-          stub.get("/users/admins") { |env| [200, {}, { :users => [ { :id => 1, :fullname => "Lindsay Fünke" } ] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :user => { :id => 1, :fullname => "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
+          stub.get("/users/admins") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
-          parse_root_in_json true, :format => :active_model_serializers
+          parse_root_in_json true, format: :active_model_serializers
           custom_get :admins
         end
       end
 
       it "parse the data from the JSON root element after .create" do
-        @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
+        @new_user = Foo::User.create(fullname: "Lindsay Fünke")
         expect(@new_user.fullname).to eq("Lindsay Fünke")
       end
 
@@ -204,28 +204,28 @@ describe Her::Model::Parse do
 
   context "when to_params is set" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| ok! :id => 1, :fullname => params(env)['fullname'] }
+          stub.post("/users") { |env| ok! id: 1, fullname: params(env)['fullname'] }
         end
       end
 
       spawn_model "Foo::User" do
         def to_params
-          { :fullname => "Lindsay Fünke" }
+          { fullname: "Lindsay Fünke" }
         end
       end
     end
 
     it "changes the request parameters for one-line resource creation" do
-      @user = Foo::User.create(:fullname => "Tobias Fünke")
+      @user = Foo::User.create(fullname: "Tobias Fünke")
       expect(@user.fullname).to eq("Lindsay Fünke")
     end
 
     it "changes the request parameters for Model.new + #save" do
-      @user = Foo::User.new(:fullname => "Tobias Fünke")
+      @user = Foo::User.new(fullname: "Tobias Fünke")
       @user.save
       expect(@user.fullname).to eq("Lindsay Fünke")
     end
@@ -233,27 +233,27 @@ describe Her::Model::Parse do
 
   context "when parse_root_in_json set json_api to true" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {},  { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/admins") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { :users => [{ :fullname => "Lindsay Fünke" }] }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { :users => [{ :id => 1, :fullname => "Tobias Fünke Jr." }] }.to_json] }
+          stub.get("/users") { |env| [200, {},  { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/admins") { |env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/1") { |env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.post("/users") { |env| [200, {}, { users: [{ fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.put("/users/1") { |env| [200, {}, { users: [{ id: 1, fullname: "Tobias Fünke Jr." }] }.to_json] }
         end
       end
 
       spawn_model("Foo::User") do
-        parse_root_in_json true, :format => :json_api
+        parse_root_in_json true, format: :json_api
         include_root_in_json true
         custom_get :admins
       end
     end
 
     it "parse the data from the JSON root element after .create" do
-      @new_user = Foo::User.create(:fullname => "Lindsay Fünke")
+      @new_user = Foo::User.create(fullname: "Lindsay Fünke")
       expect(@new_user.fullname).to eq("Lindsay Fünke")
     end
 
@@ -289,13 +289,13 @@ describe Her::Model::Parse do
 
   context "when include_root_in_json set json_api" do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.post("/users") { |env| [200, {}, { :users => [{ :id => 1, :fullname => params(env)[:users][:fullname] }] }.to_json] }
+        stub.post("/users") { |env| [200, {}, { users: [{ id: 1, fullname: params(env)[:users][:fullname] }] }.to_json] }
       end
     end
 
@@ -309,12 +309,12 @@ describe Her::Model::Parse do
       end
 
       it "wraps params in the element name in `to_params`" do
-        @new_user = Foo::User.new(:fullname => "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ :users => [{ :fullname => "Tobias Fünke" }] })
+        @new_user = Foo::User.new(fullname: "Tobias Fünke")
+        expect(@new_user.to_params).to eq({ users: [{ fullname: "Tobias Fünke" }] })
       end
 
       it "wraps params in the element name in `.where`" do
-        @new_user = Foo::User.where(:fullname => "Tobias Fünke").build
+        @new_user = Foo::User.where(fullname: "Tobias Fünke").build
         expect(@new_user.fullname).to eq("Tobias Fünke")
       end
     end
@@ -322,13 +322,13 @@ describe Her::Model::Parse do
 
   context 'when send_only_modified_attributes is set' do
     before do
-      Her::API.setup :url => "https://api.example.com", :send_only_modified_attributes => true do |builder|
+      Her::API.setup url: "https://api.example.com", send_only_modified_attributes: true do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { :id => 1, :first_name => "Gooby", :last_name => "Pls" }.to_json] }
+        stub.get("/users/1") { |env| [200, {}, { id: 1, first_name: "Gooby", last_name: "Pls" }.to_json] }
       end
 
       spawn_model "Foo::User" do
@@ -339,7 +339,7 @@ describe Her::Model::Parse do
     it 'only sends the attributes that were modified' do
       user = Foo::User.find 1
       user.first_name = 'Someone'
-      expect(user.to_params).to eql(:user => {:first_name => 'Someone'})
+      expect(user.to_params).to eql(user: {first_name: 'Someone'})
     end
   end
 end

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -26,7 +26,7 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(fullname: "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ user: { fullname: "Tobias Fünke" } })
+        expect(@new_user.to_params).to eq(user: { fullname: "Tobias Fünke" })
       end
 
       it "wraps params in the element name in `.create`" do
@@ -45,7 +45,7 @@ describe Her::Model::Parse do
 
       it "wraps params in the specified value" do
         @new_user = Foo::User.new(fullname: "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ person: { fullname: "Tobias Fünke" } })
+        expect(@new_user.to_params).to eq(person: { fullname: "Tobias Fünke" })
       end
     end
 
@@ -59,7 +59,7 @@ describe Her::Model::Parse do
 
       it "wraps params with the class name" do
         @new_user = User.new(fullname: "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ user: { fullname: "Tobias Fünke" } })
+        expect(@new_user.to_params).to eq(user: { fullname: "Tobias Fünke" })
       end
     end
   end
@@ -75,11 +75,11 @@ describe Her::Model::Parse do
     context "to true" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/admins") { |env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |_env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/admins") { |_env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
@@ -119,7 +119,7 @@ describe Her::Model::Parse do
     context "to a symbol" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { person: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { person: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
         end
 
         spawn_model("Foo::User") { parse_root_in_json :person }
@@ -134,8 +134,8 @@ describe Her::Model::Parse do
     context "in the parent class" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
         end
 
         spawn_model("Foo::Model") { parse_root_in_json true, format: :active_model_serializers }
@@ -160,11 +160,11 @@ describe Her::Model::Parse do
     context "to true with format: :active_model_serializers" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
-          stub.get("/users/admins") { |env| [200, {}, { users: [ { id: 1, fullname: "Lindsay Fünke" } ] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/admins") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
@@ -208,7 +208,7 @@ describe Her::Model::Parse do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| ok! id: 1, fullname: params(env)['fullname'] }
+          stub.post("/users") { |env| ok! id: 1, fullname: params(env)["fullname"] }
         end
       end
 
@@ -237,11 +237,11 @@ describe Her::Model::Parse do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |env| [200, {},  { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/admins") { |env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/1") { |env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.post("/users") { |env| [200, {}, { users: [{ fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.put("/users/1") { |env| [200, {}, { users: [{ id: 1, fullname: "Tobias Fünke Jr." }] }.to_json] }
+          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/admins") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/1") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.post("/users") { |_env| [200, {}, { users: [{ fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.put("/users/1") { |_env| [200, {}, { users: [{ id: 1, fullname: "Tobias Fünke Jr." }] }.to_json] }
         end
       end
 
@@ -310,7 +310,7 @@ describe Her::Model::Parse do
 
       it "wraps params in the element name in `to_params`" do
         @new_user = Foo::User.new(fullname: "Tobias Fünke")
-        expect(@new_user.to_params).to eq({ users: [{ fullname: "Tobias Fünke" }] })
+        expect(@new_user.to_params).to eq(users: [{ fullname: "Tobias Fünke" }])
       end
 
       it "wraps params in the element name in `.where`" do
@@ -320,7 +320,7 @@ describe Her::Model::Parse do
     end
   end
 
-  context 'when send_only_modified_attributes is set' do
+  context "when send_only_modified_attributes is set" do
     before do
       Her::API.setup url: "https://api.example.com", send_only_modified_attributes: true do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
@@ -328,7 +328,7 @@ describe Her::Model::Parse do
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { id: 1, first_name: "Gooby", last_name: "Pls" }.to_json] }
+        stub.get("/users/1") { |_env| [200, {}, { id: 1, first_name: "Gooby", last_name: "Pls" }.to_json] }
       end
 
       spawn_model "Foo::User" do
@@ -336,10 +336,10 @@ describe Her::Model::Parse do
       end
     end
 
-    it 'only sends the attributes that were modified' do
+    it "only sends the attributes that were modified" do
       user = Foo::User.find 1
-      user.first_name = 'Someone'
-      expect(user.to_params).to eql(user: {first_name: 'Someone'})
+      user.first_name = "Someone"
+      expect(user.to_params).to eql(user: { first_name: "Someone" })
     end
   end
 end

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -75,11 +75,11 @@ describe Her::Model::Parse do
     context "to true" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |_env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/admins") { |_env| [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
-          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/admins") { [200, {}, [{ user: { id: 1, fullname: "Lindsay Fünke" } }].to_json] }
+          stub.get("/users/1") { [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
@@ -119,7 +119,7 @@ describe Her::Model::Parse do
     context "to a symbol" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |_env| [200, {}, { person: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.post("/users") { [200, {}, { person: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
         end
 
         spawn_model("Foo::User") { parse_root_in_json :person }
@@ -134,8 +134,8 @@ describe Her::Model::Parse do
     context "in the parent class" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.post("/users") { [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
         end
 
         spawn_model("Foo::Model") { parse_root_in_json true, format: :active_model_serializers }
@@ -160,11 +160,11 @@ describe Her::Model::Parse do
     context "to true with format: :active_model_serializers" do
       before do
         Her::API.default_api.connection.adapter :test do |stub|
-          stub.post("/users") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/admins") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
-          stub.put("/users/1") { |_env| [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
+          stub.post("/users") { [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.get("/users") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/admins") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/1") { [200, {}, { user: { id: 1, fullname: "Lindsay Fünke" } }.to_json] }
+          stub.put("/users/1") { [200, {}, { user: { id: 1, fullname: "Tobias Fünke Jr." } }.to_json] }
         end
 
         spawn_model("Foo::User") do
@@ -237,11 +237,11 @@ describe Her::Model::Parse do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/admins") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.get("/users/1") { |_env| [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.post("/users") { |_env| [200, {}, { users: [{ fullname: "Lindsay Fünke" }] }.to_json] }
-          stub.put("/users/1") { |_env| [200, {}, { users: [{ id: 1, fullname: "Tobias Fünke Jr." }] }.to_json] }
+          stub.get("/users") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/admins") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.get("/users/1") { [200, {}, { users: [{ id: 1, fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.post("/users") { [200, {}, { users: [{ fullname: "Lindsay Fünke" }] }.to_json] }
+          stub.put("/users/1") { [200, {}, { users: [{ id: 1, fullname: "Tobias Fünke Jr." }] }.to_json] }
         end
       end
 
@@ -328,7 +328,7 @@ describe Her::Model::Parse do
       end
 
       Her::API.default_api.connection.adapter :test do |stub|
-        stub.get("/users/1") { |_env| [200, {}, { id: 1, first_name: "Gooby", last_name: "Pls" }.to_json] }
+        stub.get("/users/1") { [200, {}, { id: 1, first_name: "Gooby", last_name: "Pls" }.to_json] }
       end
 
       spawn_model "Foo::User" do

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -12,26 +12,26 @@ describe Her::Model::Paths do
         it "builds paths with defaults" do
           expect(Foo::User.new(id: "foo").request_path).to eq("users/foo")
           expect(Foo::User.new(id: nil).request_path).to eq("users")
-          expect(Foo::User.new().request_path).to eq("users")
+          expect(Foo::User.new.request_path).to eq("users")
         end
 
         it "builds paths with custom collection path" do
           Foo::User.collection_path "/utilisateurs"
           expect(Foo::User.new(id: "foo").request_path).to eq("/utilisateurs/foo")
-          expect(Foo::User.new().request_path).to eq("/utilisateurs")
+          expect(Foo::User.new.request_path).to eq("/utilisateurs")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::User.collection_path "utilisateurs"
           expect(Foo::User.new(id: "foo").request_path).to eq("utilisateurs/foo")
-          expect(Foo::User.new().request_path).to eq("utilisateurs")
+          expect(Foo::User.new.request_path).to eq("utilisateurs")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
 
           expect(Foo::User.new(id: "foo").request_path(_organization_id: "acme")).to eq("/organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new().request_path(_organization_id: "acme")).to eq("/organizations/acme/utilisateurs")
+          expect(Foo::User.new.request_path(_organization_id: "acme")).to eq("/organizations/acme/utilisateurs")
 
           expect(Foo::User.new(id: "foo", organization_id: "acme").request_path).to eq("/organizations/acme/utilisateurs/foo")
           expect(Foo::User.new(organization_id: "acme").request_path).to eq("/organizations/acme/utilisateurs")
@@ -41,7 +41,7 @@ describe Her::Model::Paths do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
 
           expect(Foo::User.new(id: "foo").request_path(_organization_id: "acme")).to eq("organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new().request_path(_organization_id: "acme")).to eq("organizations/acme/utilisateurs")
+          expect(Foo::User.new.request_path(_organization_id: "acme")).to eq("organizations/acme/utilisateurs")
 
           expect(Foo::User.new(id: "foo", organization_id: "acme").request_path).to eq("organizations/acme/utilisateurs/foo")
           expect(Foo::User.new(organization_id: "acme").request_path).to eq("organizations/acme/utilisateurs")
@@ -50,13 +50,13 @@ describe Her::Model::Paths do
         it "builds paths with custom item path" do
           Foo::User.resource_path "/utilisateurs/:id"
           expect(Foo::User.new(id: "foo").request_path).to eq("/utilisateurs/foo")
-          expect(Foo::User.new().request_path).to eq("users")
+          expect(Foo::User.new.request_path).to eq("users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::User.resource_path "utilisateurs/:id"
           expect(Foo::User.new(id: "foo").request_path).to eq("utilisateurs/foo")
-          expect(Foo::User.new().request_path).to eq("users")
+          expect(Foo::User.new.request_path).to eq("users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
@@ -66,8 +66,8 @@ describe Her::Model::Paths do
 
         it "escapes the variable values" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
-          expect(Foo::User.new(id: "Привет").request_path(_organization_id: 'лол')).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
-          expect(Foo::User.new(organization_id: 'лол', id: "Привет").request_path).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
+          expect(Foo::User.new(id: "Привет").request_path(_organization_id: "лол")).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
+          expect(Foo::User.new(organization_id: "лол", id: "Привет").request_path).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
         end
       end
     end
@@ -80,43 +80,43 @@ describe Her::Model::Paths do
       describe "#request_path" do
         it "builds paths with defaults" do
           expect(Foo::AdminUser.new(id: "foo").request_path).to eq("admin_users/foo")
-          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
+          expect(Foo::AdminUser.new.request_path).to eq("admin_users")
         end
 
         it "builds paths with custom collection path" do
           Foo::AdminUser.collection_path "/users"
           expect(Foo::AdminUser.new(id: "foo").request_path).to eq("/users/foo")
-          expect(Foo::AdminUser.new().request_path).to eq("/users")
+          expect(Foo::AdminUser.new.request_path).to eq("/users")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::AdminUser.collection_path "users"
           expect(Foo::AdminUser.new(id: "foo").request_path).to eq("users/foo")
-          expect(Foo::AdminUser.new().request_path).to eq("users")
+          expect(Foo::AdminUser.new.request_path).to eq("users")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
           expect(Foo::AdminUser.new(id: "foo").request_path(_organization_id: "acme")).to eq("/organizations/acme/users/foo")
-          expect(Foo::AdminUser.new().request_path(_organization_id: "acme")).to eq("/organizations/acme/users")
+          expect(Foo::AdminUser.new.request_path(_organization_id: "acme")).to eq("/organizations/acme/users")
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
           expect(Foo::AdminUser.new(id: "foo").request_path(_organization_id: "acme")).to eq("organizations/acme/users/foo")
-          expect(Foo::AdminUser.new().request_path(_organization_id: "acme")).to eq("organizations/acme/users")
+          expect(Foo::AdminUser.new.request_path(_organization_id: "acme")).to eq("organizations/acme/users")
         end
 
         it "builds paths with custom item path" do
           Foo::AdminUser.resource_path "/users/:id"
           expect(Foo::AdminUser.new(id: "foo").request_path).to eq("/users/foo")
-          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
+          expect(Foo::AdminUser.new.request_path).to eq("admin_users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::AdminUser.resource_path "users/:id"
           expect(Foo::AdminUser.new(id: "foo").request_path).to eq("users/foo")
-          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
+          expect(Foo::AdminUser.new.request_path).to eq("admin_users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
@@ -137,7 +137,7 @@ describe Her::Model::Paths do
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/foo") { |env| [200, {}, { id: 'foo' }.to_json] }
+            stub.get("/users/foo") { |_env| [200, {}, { id: "foo" }.to_json] }
           end
         end
 
@@ -148,8 +148,8 @@ describe Her::Model::Paths do
       end
 
       it "builds path using the children model name" do
-        expect(User.find('foo').id).to eq('foo')
-        expect(User.find('foo').id).to eq('foo')
+        expect(User.find("foo").id).to eq("foo")
+        expect(User.find("foo").id).to eq("foo")
       end
     end
 
@@ -166,28 +166,28 @@ describe Her::Model::Paths do
       end
     end
 
-    context 'custom primary key' do
+    context "custom primary key" do
       before do
-        spawn_model 'User' do
-          primary_key 'UserId'
-          resource_path 'users/:UserId'
+        spawn_model "User" do
+          primary_key "UserId"
+          resource_path "users/:UserId"
         end
 
-        spawn_model 'Customer' do
+        spawn_model "Customer" do
           primary_key :customer_id
-          resource_path 'customers/:id'
+          resource_path "customers/:id"
         end
       end
 
-      describe '#request_path' do
-        it 'uses the correct primary key attribute' do
-          expect(User.new(UserId: 'foo').request_path).to eq('users/foo')
-          expect(User.new(id: 'foo').request_path).to eq('users')
+      describe "#request_path" do
+        it "uses the correct primary key attribute" do
+          expect(User.new(UserId: "foo").request_path).to eq("users/foo")
+          expect(User.new(id: "foo").request_path).to eq("users")
         end
 
-        it 'replaces :id with the appropriate primary key' do
-          expect(Customer.new(customer_id: 'joe').request_path).to eq('customers/joe')
-          expect(Customer.new(id: 'joe').request_path).to eq('customers')
+        it "replaces :id with the appropriate primary key" do
+          expect(Customer.new(customer_id: "joe").request_path).to eq("customers/joe")
+          expect(Customer.new(id: "joe").request_path).to eq("customers")
         end
       end
     end
@@ -199,11 +199,11 @@ describe Her::Model::Paths do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("organizations/2/users") { |env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
-          stub.post("organizations/2/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2 }.to_json] }
-          stub.put("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2 }.to_json] }
-          stub.get("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
-          stub.delete("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2, active: false }.to_json] }
+          stub.get("organizations/2/users") { |_env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.post("organizations/2/users") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2 }.to_json] }
+          stub.put("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
+          stub.delete("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2, active: false }.to_json] }
         end
       end
 
@@ -220,7 +220,7 @@ describe Her::Model::Paths do
       end
 
       it "maps a single resource using a scope to a Ruby object" do
-        Foo::User.scope :for_organization, lambda { |o| where(organization_id: o) }
+        Foo::User.scope :for_organization, ->(o) { where(organization_id: o) }
         @user = Foo::User.for_organization(2).find(1)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
@@ -268,7 +268,7 @@ describe Her::Model::Paths do
       end
 
       it "handle resource update through the .update class method" do
-        @user = Foo::User.save_existing(1, { fullname: "Lindsay Fünke", organization_id: 2 })
+        @user = Foo::User.save_existing(1, fullname: "Lindsay Fünke", organization_id: 2)
         expect(@user.fullname).to eq("Lindsay Fünke")
       end
 
@@ -300,8 +300,8 @@ describe Her::Model::Paths do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/api/organizations/2/users") { |env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
-          stub.get("/api/organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
+          stub.get("/api/organizations/2/users") { |_env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.get("/api/organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
         end
       end
 
@@ -328,7 +328,7 @@ describe Her::Model::Paths do
 
     describe "fetching a resource with absolute path" do
       it "maps a single resource to a Ruby object" do
-        Foo::User.resource_path '/api/' + Foo::User.resource_path
+        Foo::User.resource_path "/api/" + Foo::User.resource_path
         @user = Foo::User.find(1, _organization_id: 2)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
@@ -337,7 +337,7 @@ describe Her::Model::Paths do
 
     describe "fetching a collection with absolute path" do
       it "maps a collection of resources to an array of Ruby objects" do
-        Foo::User.collection_path '/api/' + Foo::User.collection_path
+        Foo::User.collection_path "/api/" + Foo::User.collection_path
         @users = Foo::User.where(_organization_id: 2).all
         expect(@users.length).to eq(2)
         expect(@users.first.fullname).to eq("Tobias Fünke")

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -10,53 +10,53 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::User.new(:id => "foo").request_path.should == "users/foo"
-          Foo::User.new(:id => nil).request_path.should == "users"
-          Foo::User.new().request_path.should == "users"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::User.new(:id => nil).request_path).to eq("users")
+          expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "builds paths with custom collection path" do
           Foo::User.collection_path "/utilisateurs"
-          Foo::User.new(:id => "foo").request_path.should == "/utilisateurs/foo"
-          Foo::User.new().request_path.should == "/utilisateurs"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("/utilisateurs/foo")
+          expect(Foo::User.new().request_path).to eq("/utilisateurs")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::User.collection_path "utilisateurs"
-          Foo::User.new(:id => "foo").request_path.should == "utilisateurs/foo"
-          Foo::User.new().request_path.should == "utilisateurs"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("utilisateurs/foo")
+          expect(Foo::User.new().request_path).to eq("utilisateurs")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
 
-          Foo::User.new(:id => "foo").request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.new().request_path(:_organization_id => "acme").should == "/organizations/acme/utilisateurs"
+          expect(Foo::User.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("/organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new().request_path(:_organization_id => "acme")).to eq("/organizations/acme/utilisateurs")
 
-          Foo::User.new(:id => "foo", :organization_id => "acme").request_path.should == "/organizations/acme/utilisateurs/foo"
-          Foo::User.new(:organization_id => "acme").request_path.should == "/organizations/acme/utilisateurs"
+          expect(Foo::User.new(:id => "foo", :organization_id => "acme").request_path).to eq("/organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new(:organization_id => "acme").request_path).to eq("/organizations/acme/utilisateurs")
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
 
-          Foo::User.new(:id => "foo").request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs/foo"
-          Foo::User.new().request_path(:_organization_id => "acme").should == "organizations/acme/utilisateurs"
+          expect(Foo::User.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new().request_path(:_organization_id => "acme")).to eq("organizations/acme/utilisateurs")
 
-          Foo::User.new(:id => "foo", :organization_id => "acme").request_path.should == "organizations/acme/utilisateurs/foo"
-          Foo::User.new(:organization_id => "acme").request_path.should == "organizations/acme/utilisateurs"
+          expect(Foo::User.new(:id => "foo", :organization_id => "acme").request_path).to eq("organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new(:organization_id => "acme").request_path).to eq("organizations/acme/utilisateurs")
         end
 
         it "builds paths with custom item path" do
           Foo::User.resource_path "/utilisateurs/:id"
-          Foo::User.new(:id => "foo").request_path.should == "/utilisateurs/foo"
-          Foo::User.new().request_path.should == "users"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("/utilisateurs/foo")
+          expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::User.resource_path "utilisateurs/:id"
-          Foo::User.new(:id => "foo").request_path.should == "utilisateurs/foo"
-          Foo::User.new().request_path.should == "users"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("utilisateurs/foo")
+          expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
@@ -66,8 +66,8 @@ describe Her::Model::Paths do
 
         it "escapes the variable values" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
-          Foo::User.new(:id => "Привет").request_path(:_organization_id => 'лол').should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
-          Foo::User.new(:organization_id => 'лол', :id => "Привет").request_path.should == "organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82"
+          expect(Foo::User.new(:id => "Привет").request_path(:_organization_id => 'лол')).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
+          expect(Foo::User.new(:organization_id => 'лол', :id => "Привет").request_path).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
         end
       end
     end
@@ -79,44 +79,44 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::AdminUser.new(:id => "foo").request_path.should == "admin_users/foo"
-          Foo::AdminUser.new().request_path.should == "admin_users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("admin_users/foo")
+          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "builds paths with custom collection path" do
           Foo::AdminUser.collection_path "/users"
-          Foo::AdminUser.new(:id => "foo").request_path.should == "/users/foo"
-          Foo::AdminUser.new().request_path.should == "/users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("/users/foo")
+          expect(Foo::AdminUser.new().request_path).to eq("/users")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::AdminUser.collection_path "users"
-          Foo::AdminUser.new(:id => "foo").request_path.should == "users/foo"
-          Foo::AdminUser.new().request_path.should == "users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::AdminUser.new().request_path).to eq("users")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme").should == "/organizations/acme/users/foo"
-          Foo::AdminUser.new().request_path(:_organization_id => "acme").should == "/organizations/acme/users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("/organizations/acme/users/foo")
+          expect(Foo::AdminUser.new().request_path(:_organization_id => "acme")).to eq("/organizations/acme/users")
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme").should == "organizations/acme/users/foo"
-          Foo::AdminUser.new().request_path(:_organization_id => "acme").should == "organizations/acme/users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("organizations/acme/users/foo")
+          expect(Foo::AdminUser.new().request_path(:_organization_id => "acme")).to eq("organizations/acme/users")
         end
 
         it "builds paths with custom item path" do
           Foo::AdminUser.resource_path "/users/:id"
-          Foo::AdminUser.new(:id => "foo").request_path.should == "/users/foo"
-          Foo::AdminUser.new().request_path.should == "admin_users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("/users/foo")
+          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::AdminUser.resource_path "users/:id"
-          Foo::AdminUser.new(:id => "foo").request_path.should == "users/foo"
-          Foo::AdminUser.new().request_path.should == "admin_users"
+          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
@@ -148,8 +148,8 @@ describe Her::Model::Paths do
       end
 
       it "builds path using the children model name" do
-        User.find('foo').id.should == 'foo'
-        User.find('foo').id.should == 'foo'
+        expect(User.find('foo').id).to eq('foo')
+        expect(User.find('foo').id).to eq('foo')
       end
     end
 
@@ -160,8 +160,8 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          Foo::User.new(:id => "foo").request_path.should == "users/foo"
-          Foo::User.new.request_path.should == "users"
+          expect(Foo::User.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::User.new.request_path).to eq("users")
         end
       end
     end
@@ -181,13 +181,13 @@ describe Her::Model::Paths do
 
       describe '#request_path' do
         it 'uses the correct primary key attribute' do
-          User.new(:UserId => 'foo').request_path.should == 'users/foo'
-          User.new(:id => 'foo').request_path.should == 'users'
+          expect(User.new(:UserId => 'foo').request_path).to eq('users/foo')
+          expect(User.new(:id => 'foo').request_path).to eq('users')
         end
 
         it 'replaces :id with the appropriate primary key' do
-          Customer.new(:customer_id => 'joe').request_path.should == 'customers/joe'
-          Customer.new(:id => 'joe').request_path.should == 'customers'
+          expect(Customer.new(:customer_id => 'joe').request_path).to eq('customers/joe')
+          expect(Customer.new(:id => 'joe').request_path).to eq('customers')
         end
       end
     end
@@ -215,81 +215,81 @@ describe Her::Model::Paths do
     describe "fetching a resource" do
       it "maps a single resource to a Ruby object" do
         @user = Foo::User.find(1, :_organization_id => 2)
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
 
       it "maps a single resource using a scope to a Ruby object" do
         Foo::User.scope :for_organization, lambda { |o| where(:organization_id => o) }
         @user = Foo::User.for_organization(2).find(1)
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
     end
 
     describe "fetching a collection" do
       it "maps a collection of resources to an array of Ruby objects" do
         @users = Foo::User.where(:_organization_id => 2).all
-        @users.length.should == 2
-        @users.first.fullname.should == "Tobias Fünke"
+        expect(@users.length).to eq(2)
+        expect(@users.first.fullname).to eq("Tobias Fünke")
       end
     end
 
     describe "handling new resource" do
       it "handles new resource" do
         @new_user = Foo::User.new(:fullname => "Tobias Fünke", :organization_id => 2)
-        @new_user.new?.should be_truthy
+        expect(@new_user.new?).to be_truthy
 
         @existing_user = Foo::User.find(1, :_organization_id => 2)
-        @existing_user.new?.should be_falsey
+        expect(@existing_user.new?).to be_falsey
       end
     end
 
     describe "creating resources" do
       it "handle one-line resource creation" do
         @user = Foo::User.create(:fullname => "Tobias Fünke", :organization_id => 2)
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
 
       it "handle resource creation through Model.new + #save" do
         @user = Foo::User.new(:fullname => "Tobias Fünke", :organization_id => 2)
         @user.save
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
     end
 
     context "updating resources" do
       it "handle resource data update without saving it" do
         @user = Foo::User.find(1, :_organization_id => 2)
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.fullname).to eq("Tobias Fünke")
         @user.fullname = "Kittie Sanchez"
-        @user.fullname.should == "Kittie Sanchez"
+        expect(@user.fullname).to eq("Kittie Sanchez")
       end
 
       it "handle resource update through the .update class method" do
         @user = Foo::User.save_existing(1, { :fullname => "Lindsay Fünke", :organization_id => 2 })
-        @user.fullname.should == "Lindsay Fünke"
+        expect(@user.fullname).to eq("Lindsay Fünke")
       end
 
       it "handle resource update through #save on an existing resource" do
         @user = Foo::User.find(1, :_organization_id => 2)
         @user.fullname = "Lindsay Fünke"
         @user.save
-        @user.fullname.should == "Lindsay Fünke"
+        expect(@user.fullname).to eq("Lindsay Fünke")
       end
     end
 
     context "deleting resources" do
       it "handle resource deletion through the .destroy class method" do
         @user = Foo::User.destroy_existing(1, :_organization_id => 2)
-        @user.active.should be_falsey
+        expect(@user.active).to be_falsey
       end
 
       it "handle resource deletion through #destroy on an existing resource" do
         @user = Foo::User.find(1, :_organization_id => 2)
         @user.destroy
-        @user.active.should be_falsey
+        expect(@user.active).to be_falsey
       end
     end
   end
@@ -313,16 +313,16 @@ describe Her::Model::Paths do
     describe "fetching a resource" do
       it "maps a single resource to a Ruby object" do
         @user = Foo::User.find(1, :_organization_id => 2)
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
     end
 
     describe "fetching a collection" do
       it "maps a collection of resources to an array of Ruby objects" do
         @users = Foo::User.where(:_organization_id => 2).all
-        @users.length.should == 2
-        @users.first.fullname.should == "Tobias Fünke"
+        expect(@users.length).to eq(2)
+        expect(@users.first.fullname).to eq("Tobias Fünke")
       end
     end
 
@@ -330,8 +330,8 @@ describe Her::Model::Paths do
       it "maps a single resource to a Ruby object" do
         Foo::User.resource_path '/api/' + Foo::User.resource_path
         @user = Foo::User.find(1, :_organization_id => 2)
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
       end
     end
 
@@ -339,8 +339,8 @@ describe Her::Model::Paths do
       it "maps a collection of resources to an array of Ruby objects" do
         Foo::User.collection_path '/api/' + Foo::User.collection_path
         @users = Foo::User.where(:_organization_id => 2).all
-        @users.length.should == 2
-        @users.first.fullname.should == "Tobias Fünke"
+        expect(@users.length).to eq(2)
+        expect(@users.first.fullname).to eq("Tobias Fünke")
       end
     end
   end

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -137,7 +137,7 @@ describe Her::Model::Paths do
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/foo") { |_env| [200, {}, { id: "foo" }.to_json] }
+            stub.get("/users/foo") { [200, {}, { id: "foo" }.to_json] }
           end
         end
 
@@ -199,11 +199,11 @@ describe Her::Model::Paths do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("organizations/2/users") { |_env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
-          stub.post("organizations/2/users") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2 }.to_json] }
-          stub.put("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2 }.to_json] }
-          stub.get("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
-          stub.delete("organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2, active: false }.to_json] }
+          stub.get("organizations/2/users") { [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.post("organizations/2/users") { [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2 }.to_json] }
+          stub.put("organizations/2/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("organizations/2/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
+          stub.delete("organizations/2/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2, active: false }.to_json] }
         end
       end
 
@@ -300,8 +300,8 @@ describe Her::Model::Paths do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/api/organizations/2/users") { |_env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
-          stub.get("/api/organizations/2/users/1") { |_env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
+          stub.get("/api/organizations/2/users") { [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.get("/api/organizations/2/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
         end
       end
 

--- a/spec/model/paths_spec.rb
+++ b/spec/model/paths_spec.rb
@@ -10,64 +10,64 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          expect(Foo::User.new(:id => "foo").request_path).to eq("users/foo")
-          expect(Foo::User.new(:id => nil).request_path).to eq("users")
+          expect(Foo::User.new(id: "foo").request_path).to eq("users/foo")
+          expect(Foo::User.new(id: nil).request_path).to eq("users")
           expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "builds paths with custom collection path" do
           Foo::User.collection_path "/utilisateurs"
-          expect(Foo::User.new(:id => "foo").request_path).to eq("/utilisateurs/foo")
+          expect(Foo::User.new(id: "foo").request_path).to eq("/utilisateurs/foo")
           expect(Foo::User.new().request_path).to eq("/utilisateurs")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::User.collection_path "utilisateurs"
-          expect(Foo::User.new(:id => "foo").request_path).to eq("utilisateurs/foo")
+          expect(Foo::User.new(id: "foo").request_path).to eq("utilisateurs/foo")
           expect(Foo::User.new().request_path).to eq("utilisateurs")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
 
-          expect(Foo::User.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("/organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new().request_path(:_organization_id => "acme")).to eq("/organizations/acme/utilisateurs")
+          expect(Foo::User.new(id: "foo").request_path(_organization_id: "acme")).to eq("/organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new().request_path(_organization_id: "acme")).to eq("/organizations/acme/utilisateurs")
 
-          expect(Foo::User.new(:id => "foo", :organization_id => "acme").request_path).to eq("/organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new(:organization_id => "acme").request_path).to eq("/organizations/acme/utilisateurs")
+          expect(Foo::User.new(id: "foo", organization_id: "acme").request_path).to eq("/organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new(organization_id: "acme").request_path).to eq("/organizations/acme/utilisateurs")
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
 
-          expect(Foo::User.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new().request_path(:_organization_id => "acme")).to eq("organizations/acme/utilisateurs")
+          expect(Foo::User.new(id: "foo").request_path(_organization_id: "acme")).to eq("organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new().request_path(_organization_id: "acme")).to eq("organizations/acme/utilisateurs")
 
-          expect(Foo::User.new(:id => "foo", :organization_id => "acme").request_path).to eq("organizations/acme/utilisateurs/foo")
-          expect(Foo::User.new(:organization_id => "acme").request_path).to eq("organizations/acme/utilisateurs")
+          expect(Foo::User.new(id: "foo", organization_id: "acme").request_path).to eq("organizations/acme/utilisateurs/foo")
+          expect(Foo::User.new(organization_id: "acme").request_path).to eq("organizations/acme/utilisateurs")
         end
 
         it "builds paths with custom item path" do
           Foo::User.resource_path "/utilisateurs/:id"
-          expect(Foo::User.new(:id => "foo").request_path).to eq("/utilisateurs/foo")
+          expect(Foo::User.new(id: "foo").request_path).to eq("/utilisateurs/foo")
           expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::User.resource_path "utilisateurs/:id"
-          expect(Foo::User.new(:id => "foo").request_path).to eq("utilisateurs/foo")
+          expect(Foo::User.new(id: "foo").request_path).to eq("utilisateurs/foo")
           expect(Foo::User.new().request_path).to eq("users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::User.collection_path "/organizations/:organization_id/utilisateurs"
-          expect { Foo::User.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::User.new(id: "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/utilisateurs/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
 
         it "escapes the variable values" do
           Foo::User.collection_path "organizations/:organization_id/utilisateurs"
-          expect(Foo::User.new(:id => "Привет").request_path(:_organization_id => 'лол')).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
-          expect(Foo::User.new(:organization_id => 'лол', :id => "Привет").request_path).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
+          expect(Foo::User.new(id: "Привет").request_path(_organization_id: 'лол')).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
+          expect(Foo::User.new(organization_id: 'лол', id: "Привет").request_path).to eq("organizations/%D0%BB%D0%BE%D0%BB/utilisateurs/%D0%9F%D1%80%D0%B8%D0%B2%D0%B5%D1%82")
         end
       end
     end
@@ -79,65 +79,65 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("admin_users/foo")
+          expect(Foo::AdminUser.new(id: "foo").request_path).to eq("admin_users/foo")
           expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "builds paths with custom collection path" do
           Foo::AdminUser.collection_path "/users"
-          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("/users/foo")
+          expect(Foo::AdminUser.new(id: "foo").request_path).to eq("/users/foo")
           expect(Foo::AdminUser.new().request_path).to eq("/users")
         end
 
         it "builds paths with custom relative collection path" do
           Foo::AdminUser.collection_path "users"
-          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::AdminUser.new(id: "foo").request_path).to eq("users/foo")
           expect(Foo::AdminUser.new().request_path).to eq("users")
         end
 
         it "builds paths with custom collection path with multiple variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          expect(Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("/organizations/acme/users/foo")
-          expect(Foo::AdminUser.new().request_path(:_organization_id => "acme")).to eq("/organizations/acme/users")
+          expect(Foo::AdminUser.new(id: "foo").request_path(_organization_id: "acme")).to eq("/organizations/acme/users/foo")
+          expect(Foo::AdminUser.new().request_path(_organization_id: "acme")).to eq("/organizations/acme/users")
         end
 
         it "builds paths with custom relative collection path with multiple variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          expect(Foo::AdminUser.new(:id => "foo").request_path(:_organization_id => "acme")).to eq("organizations/acme/users/foo")
-          expect(Foo::AdminUser.new().request_path(:_organization_id => "acme")).to eq("organizations/acme/users")
+          expect(Foo::AdminUser.new(id: "foo").request_path(_organization_id: "acme")).to eq("organizations/acme/users/foo")
+          expect(Foo::AdminUser.new().request_path(_organization_id: "acme")).to eq("organizations/acme/users")
         end
 
         it "builds paths with custom item path" do
           Foo::AdminUser.resource_path "/users/:id"
-          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("/users/foo")
+          expect(Foo::AdminUser.new(id: "foo").request_path).to eq("/users/foo")
           expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "builds paths with custom relative item path" do
           Foo::AdminUser.resource_path "users/:id"
-          expect(Foo::AdminUser.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::AdminUser.new(id: "foo").request_path).to eq("users/foo")
           expect(Foo::AdminUser.new().request_path).to eq("admin_users")
         end
 
         it "raises exceptions when building a path without required custom variables" do
           Foo::AdminUser.collection_path "/organizations/:organization_id/users"
-          expect { Foo::AdminUser.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.new(id: "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `/organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
 
         it "raises exceptions when building a relative path without required custom variables" do
           Foo::AdminUser.collection_path "organizations/:organization_id/users"
-          expect { Foo::AdminUser.new(:id => "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
+          expect { Foo::AdminUser.new(id: "foo").request_path }.to raise_error(Her::Errors::PathError, "Missing :_organization_id parameter to build the request path. Path is `organizations/:organization_id/users/:id`. Parameters are `{:id=>\"foo\"}`.")
         end
       end
     end
 
     context "children model" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users/foo") { |env| [200, {}, { :id => 'foo' }.to_json] }
+            stub.get("/users/foo") { |env| [200, {}, { id: 'foo' }.to_json] }
           end
         end
 
@@ -160,7 +160,7 @@ describe Her::Model::Paths do
 
       describe "#request_path" do
         it "builds paths with defaults" do
-          expect(Foo::User.new(:id => "foo").request_path).to eq("users/foo")
+          expect(Foo::User.new(id: "foo").request_path).to eq("users/foo")
           expect(Foo::User.new.request_path).to eq("users")
         end
       end
@@ -181,13 +181,13 @@ describe Her::Model::Paths do
 
       describe '#request_path' do
         it 'uses the correct primary key attribute' do
-          expect(User.new(:UserId => 'foo').request_path).to eq('users/foo')
-          expect(User.new(:id => 'foo').request_path).to eq('users')
+          expect(User.new(UserId: 'foo').request_path).to eq('users/foo')
+          expect(User.new(id: 'foo').request_path).to eq('users')
         end
 
         it 'replaces :id with the appropriate primary key' do
-          expect(Customer.new(:customer_id => 'joe').request_path).to eq('customers/joe')
-          expect(Customer.new(:id => 'joe').request_path).to eq('customers')
+          expect(Customer.new(customer_id: 'joe').request_path).to eq('customers/joe')
+          expect(Customer.new(id: 'joe').request_path).to eq('customers')
         end
       end
     end
@@ -195,15 +195,15 @@ describe Her::Model::Paths do
 
   context "making subdomain HTTP requests" do
     before do
-      Her::API.setup :url => "https://api.example.com/" do |builder|
+      Her::API.setup url: "https://api.example.com/" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("organizations/2/users") { |env| [200, {}, [{ :id => 1, :fullname => "Tobias Fünke", :organization_id => 2 }, { :id => 2, :fullname => "Lindsay Fünke", :organization_id => 2 }].to_json] }
-          stub.post("organizations/2/users") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :organization_id => 2 }.to_json] }
-          stub.put("organizations/2/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke", :organization_id => 2 }.to_json] }
-          stub.get("organizations/2/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :organization_id => 2, :active => true }.to_json] }
-          stub.delete("organizations/2/users/1") { |env| [200, {}, { :id => 1, :fullname => "Lindsay Fünke", :organization_id => 2, :active => false }.to_json] }
+          stub.get("organizations/2/users") { |env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.post("organizations/2/users") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2 }.to_json] }
+          stub.put("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2 }.to_json] }
+          stub.get("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
+          stub.delete("organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Lindsay Fünke", organization_id: 2, active: false }.to_json] }
         end
       end
 
@@ -214,13 +214,13 @@ describe Her::Model::Paths do
 
     describe "fetching a resource" do
       it "maps a single resource to a Ruby object" do
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
       end
 
       it "maps a single resource using a scope to a Ruby object" do
-        Foo::User.scope :for_organization, lambda { |o| where(:organization_id => o) }
+        Foo::User.scope :for_organization, lambda { |o| where(organization_id: o) }
         @user = Foo::User.for_organization(2).find(1)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
@@ -229,7 +229,7 @@ describe Her::Model::Paths do
 
     describe "fetching a collection" do
       it "maps a collection of resources to an array of Ruby objects" do
-        @users = Foo::User.where(:_organization_id => 2).all
+        @users = Foo::User.where(_organization_id: 2).all
         expect(@users.length).to eq(2)
         expect(@users.first.fullname).to eq("Tobias Fünke")
       end
@@ -237,23 +237,23 @@ describe Her::Model::Paths do
 
     describe "handling new resource" do
       it "handles new resource" do
-        @new_user = Foo::User.new(:fullname => "Tobias Fünke", :organization_id => 2)
+        @new_user = Foo::User.new(fullname: "Tobias Fünke", organization_id: 2)
         expect(@new_user.new?).to be_truthy
 
-        @existing_user = Foo::User.find(1, :_organization_id => 2)
+        @existing_user = Foo::User.find(1, _organization_id: 2)
         expect(@existing_user.new?).to be_falsey
       end
     end
 
     describe "creating resources" do
       it "handle one-line resource creation" do
-        @user = Foo::User.create(:fullname => "Tobias Fünke", :organization_id => 2)
+        @user = Foo::User.create(fullname: "Tobias Fünke", organization_id: 2)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
       end
 
       it "handle resource creation through Model.new + #save" do
-        @user = Foo::User.new(:fullname => "Tobias Fünke", :organization_id => 2)
+        @user = Foo::User.new(fullname: "Tobias Fünke", organization_id: 2)
         @user.save
         expect(@user.fullname).to eq("Tobias Fünke")
       end
@@ -261,19 +261,19 @@ describe Her::Model::Paths do
 
     context "updating resources" do
       it "handle resource data update without saving it" do
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         expect(@user.fullname).to eq("Tobias Fünke")
         @user.fullname = "Kittie Sanchez"
         expect(@user.fullname).to eq("Kittie Sanchez")
       end
 
       it "handle resource update through the .update class method" do
-        @user = Foo::User.save_existing(1, { :fullname => "Lindsay Fünke", :organization_id => 2 })
+        @user = Foo::User.save_existing(1, { fullname: "Lindsay Fünke", organization_id: 2 })
         expect(@user.fullname).to eq("Lindsay Fünke")
       end
 
       it "handle resource update through #save on an existing resource" do
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         @user.fullname = "Lindsay Fünke"
         @user.save
         expect(@user.fullname).to eq("Lindsay Fünke")
@@ -282,12 +282,12 @@ describe Her::Model::Paths do
 
     context "deleting resources" do
       it "handle resource deletion through the .destroy class method" do
-        @user = Foo::User.destroy_existing(1, :_organization_id => 2)
+        @user = Foo::User.destroy_existing(1, _organization_id: 2)
         expect(@user.active).to be_falsey
       end
 
       it "handle resource deletion through #destroy on an existing resource" do
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         @user.destroy
         expect(@user.active).to be_falsey
       end
@@ -296,12 +296,12 @@ describe Her::Model::Paths do
 
   context "making path HTTP requests" do
     before do
-      Her::API.setup :url => "https://example.com/api/" do |builder|
+      Her::API.setup url: "https://example.com/api/" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/api/organizations/2/users") { |env| [200, {}, [{ :id => 1, :fullname => "Tobias Fünke", :organization_id => 2 }, { :id => 2, :fullname => "Lindsay Fünke", :organization_id => 2 }].to_json] }
-          stub.get("/api/organizations/2/users/1") { |env| [200, {}, { :id => 1, :fullname => "Tobias Fünke", :organization_id => 2, :active => true }.to_json] }
+          stub.get("/api/organizations/2/users") { |env| [200, {}, [{ id: 1, fullname: "Tobias Fünke", organization_id: 2 }, { id: 2, fullname: "Lindsay Fünke", organization_id: 2 }].to_json] }
+          stub.get("/api/organizations/2/users/1") { |env| [200, {}, { id: 1, fullname: "Tobias Fünke", organization_id: 2, active: true }.to_json] }
         end
       end
 
@@ -312,7 +312,7 @@ describe Her::Model::Paths do
 
     describe "fetching a resource" do
       it "maps a single resource to a Ruby object" do
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
       end
@@ -320,7 +320,7 @@ describe Her::Model::Paths do
 
     describe "fetching a collection" do
       it "maps a collection of resources to an array of Ruby objects" do
-        @users = Foo::User.where(:_organization_id => 2).all
+        @users = Foo::User.where(_organization_id: 2).all
         expect(@users.length).to eq(2)
         expect(@users.first.fullname).to eq("Tobias Fünke")
       end
@@ -329,7 +329,7 @@ describe Her::Model::Paths do
     describe "fetching a resource with absolute path" do
       it "maps a single resource to a Ruby object" do
         Foo::User.resource_path '/api/' + Foo::User.resource_path
-        @user = Foo::User.find(1, :_organization_id => 2)
+        @user = Foo::User.find(1, _organization_id: 2)
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
       end
@@ -338,7 +338,7 @@ describe Her::Model::Paths do
     describe "fetching a collection with absolute path" do
       it "maps a collection of resources to an array of Ruby objects" do
         Foo::User.collection_path '/api/' + Foo::User.collection_path
-        @users = Foo::User.where(:_organization_id => 2).all
+        @users = Foo::User.where(_organization_id: 2).all
         expect(@users.length).to eq(2)
         expect(@users.first.fullname).to eq("Tobias Fünke")
       end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -8,19 +8,19 @@ describe Her::Model::Relation do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?foo=1&bar=2") { |env| ok! [{ id: 2, fullname: "Tobias Fünke" }] }
-            stub.get("/users?admin=1") { |env| ok! [{ id: 1, fullname: "Tobias Fünke" }] }
+            stub.get("/users?foo=1&bar=2") { |_env| ok! [{ id: 2, fullname: "Tobias Fünke" }] }
+            stub.get("/users?admin=1") { |_env| ok! [{ id: 1, fullname: "Tobias Fünke" }] }
 
-            stub.get("/users") do |env|
+            stub.get("/users") do |_env|
               ok! [
                 { id: 1, fullname: "Tobias Fünke" },
                 { id: 2, fullname: "Lindsay Fünke" },
-                @created_user,
+                @created_user
               ].compact
             end
 
-            stub.post('/users') do |env|
-              @created_user = { id: 3, fullname: 'George Michael Bluth' }
+            stub.post("/users") do |_env|
+              @created_user = { id: 3, fullname: "George Michael Bluth" }
               ok! @created_user
             end
           end
@@ -48,7 +48,7 @@ describe Her::Model::Relation do
 
       it "does not reuse relations" do
         expect(Foo::User.all.size).to eql 2
-        expect(Foo::User.create(fullname: 'George Michael Bluth').id).to eq(3)
+        expect(Foo::User.create(fullname: "George Michael Bluth").id).to eq(3)
         expect(Foo::User.all.size).to eql 3
       end
     end
@@ -58,12 +58,12 @@ describe Her::Model::Relation do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?page=2") { |env| ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }] }
+            stub.get("/users?page=2") { |_env| ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }] }
           end
         end
 
         spawn_model("Foo::Model") do
-          scope :page, lambda { |page| where(page: page) }
+          scope :page, ->(page) { where(page: page) }
         end
 
         class User < Foo::Model; end
@@ -124,16 +124,16 @@ describe Her::Model::Relation do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.get("/users?what=4&where=3") { |env| ok! [{ id: 3, fullname: "Maeby Fünke" }] }
-          stub.get("/users?what=2") { |env| ok! [{ id: 2, fullname: "Lindsay Fünke" }] }
-          stub.get("/users?where=6") { |env| ok! [{ id: 4, fullname: "Tobias Fünke" }] }
+          stub.get("/users?what=4&where=3") { |_env| ok! [{ id: 3, fullname: "Maeby Fünke" }] }
+          stub.get("/users?what=2") { |_env| ok! [{ id: 2, fullname: "Lindsay Fünke" }] }
+          stub.get("/users?where=6") { |_env| ok! [{ id: 4, fullname: "Tobias Fünke" }] }
         end
       end
 
-      spawn_model 'Foo::User' do
-        scope :foo, lambda { |v| where(what: v) }
-        scope :bar, lambda { |v| where(where: v) }
-        scope :baz, lambda { bar(6) }
+      spawn_model "Foo::User" do
+        scope :foo, ->(v) { where(what: v) }
+        scope :bar, ->(v) { where(where: v) }
+        scope :baz, -> { bar(6) }
       end
     end
 
@@ -156,9 +156,9 @@ describe Her::Model::Relation do
   describe :default_scope do
     context "for new objects" do
       before do
-        spawn_model 'Foo::User' do
-          default_scope lambda { where(active: true) }
-          default_scope lambda { where(admin: true) }
+        spawn_model "Foo::User" do
+          default_scope -> { where(active: true) }
+          default_scope -> { where(admin: true) }
         end
       end
 
@@ -178,8 +178,8 @@ describe Her::Model::Relation do
           end
         end
 
-        spawn_model 'Foo::User' do
-          default_scope lambda { where(active: true) }
+        spawn_model "Foo::User" do
+          default_scope -> { where(active: true) }
         end
       end
 
@@ -196,8 +196,8 @@ describe Her::Model::Relation do
           end
         end
 
-        spawn_model 'Foo::User' do
-          default_scope lambda { where(active: true) }
+        spawn_model "Foo::User" do
+          default_scope -> { where(active: true) }
         end
       end
 
@@ -210,13 +210,13 @@ describe Her::Model::Relation do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.get("/users") do |env|
+          stub.get("/users") do |_env|
             ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }]
           end
         end
       end
 
-      spawn_model 'Foo::User'
+      spawn_model "Foo::User"
     end
 
     it "delegates the method to the fetched collection" do

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -8,10 +8,10 @@ describe Her::Model::Relation do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?foo=1&bar=2") { |_env| ok! [{ id: 2, fullname: "Tobias Fünke" }] }
-            stub.get("/users?admin=1") { |_env| ok! [{ id: 1, fullname: "Tobias Fünke" }] }
+            stub.get("/users?foo=1&bar=2") { ok! [{ id: 2, fullname: "Tobias Fünke" }] }
+            stub.get("/users?admin=1") { ok! [{ id: 1, fullname: "Tobias Fünke" }] }
 
-            stub.get("/users") do |_env|
+            stub.get("/users") do
               ok! [
                 { id: 1, fullname: "Tobias Fünke" },
                 { id: 2, fullname: "Lindsay Fünke" },
@@ -19,7 +19,7 @@ describe Her::Model::Relation do
               ].compact
             end
 
-            stub.post("/users") do |_env|
+            stub.post("/users") do
               @created_user = { id: 3, fullname: "George Michael Bluth" }
               ok! @created_user
             end
@@ -58,7 +58,7 @@ describe Her::Model::Relation do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?page=2") { |_env| ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }] }
+            stub.get("/users?page=2") { ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }] }
           end
         end
 
@@ -124,9 +124,9 @@ describe Her::Model::Relation do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.get("/users?what=4&where=3") { |_env| ok! [{ id: 3, fullname: "Maeby Fünke" }] }
-          stub.get("/users?what=2") { |_env| ok! [{ id: 2, fullname: "Lindsay Fünke" }] }
-          stub.get("/users?where=6") { |_env| ok! [{ id: 4, fullname: "Tobias Fünke" }] }
+          stub.get("/users?what=4&where=3") { ok! [{ id: 3, fullname: "Maeby Fünke" }] }
+          stub.get("/users?what=2") { ok! [{ id: 2, fullname: "Lindsay Fünke" }] }
+          stub.get("/users?where=6") { ok! [{ id: 4, fullname: "Tobias Fünke" }] }
         end
       end
 
@@ -210,7 +210,7 @@ describe Her::Model::Relation do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.get("/users") do |_env|
+          stub.get("/users") do
             ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }]
           end
         end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -30,26 +30,26 @@ describe Her::Model::Relation do
       end
 
       it "doesn't fetch the data immediatly" do
-        Foo::User.should_receive(:request).never
+        expect(Foo::User).to receive(:request).never
         @users = Foo::User.where(:admin => 1)
       end
 
       it "fetches the data and passes query parameters" do
-        Foo::User.should_receive(:request).once.and_call_original
+        expect(Foo::User).to receive(:request).once.and_call_original
         @users = Foo::User.where(:admin => 1)
-        @users.should respond_to(:length)
-        @users.size.should eql 1
+        expect(@users).to respond_to(:length)
+        expect(@users.size).to eql 1
       end
 
       it "chains multiple where statements" do
         @user = Foo::User.where(:foo => 1).where(:bar => 2).first
-        @user.id.should == 2
+        expect(@user.id).to eq(2)
       end
 
       it "does not reuse relations" do
-        Foo::User.all.size.should eql 2
-        Foo::User.create(:fullname => 'George Michael Bluth').id.should == 3
-        Foo::User.all.size.should eql 3
+        expect(Foo::User.all.size).to eql 2
+        expect(Foo::User.create(:fullname => 'George Michael Bluth').id).to eq(3)
+        expect(Foo::User.all.size).to eql 3
       end
     end
 
@@ -72,7 +72,7 @@ describe Her::Model::Relation do
 
       it "propagates the scopes through its children" do
         @users = User.page(2)
-        @users.length.should == 2
+        expect(@users.length).to eq(2)
       end
     end
   end
@@ -93,18 +93,18 @@ describe Her::Model::Relation do
     context "with a single where call" do
       it "creates a resource and passes the query parameters" do
         @user = Foo::User.where(:fullname => "Tobias Fünke", :email => "tobias@bluth.com").create
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
-        @user.email.should == "tobias@bluth.com"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
+        expect(@user.email).to eq("tobias@bluth.com")
       end
     end
 
     context "with multiple where calls" do
       it "creates a resource and passes the query parameters" do
         @user = Foo::User.where(:fullname => "Tobias Fünke").create(:email => "tobias@bluth.com")
-        @user.id.should == 1
-        @user.fullname.should == "Tobias Fünke"
-        @user.email.should == "tobias@bluth.com"
+        expect(@user.id).to eq(1)
+        expect(@user.fullname).to eq("Tobias Fünke")
+        expect(@user.email).to eq("tobias@bluth.com")
       end
     end
   end
@@ -114,8 +114,8 @@ describe Her::Model::Relation do
 
     it "handles new resource with build" do
       @new_user = Foo::User.where(:fullname => "Tobias Fünke").build
-      @new_user.new?.should be_truthy
-      @new_user.fullname.should == "Tobias Fünke"
+      expect(@new_user.new?).to be_truthy
+      expect(@new_user.fullname).to eq("Tobias Fünke")
     end
   end
 
@@ -139,17 +139,17 @@ describe Her::Model::Relation do
 
     it "passes query parameters" do
       @user = Foo::User.foo(2).first
-      @user.id.should == 2
+      expect(@user.id).to eq(2)
     end
 
     it "passes multiple query parameters" do
       @user = Foo::User.foo(4).bar(3).first
-      @user.id.should == 3
+      expect(@user.id).to eq(3)
     end
 
     it "handles embedded scopes" do
       @user = Foo::User.baz.first
-      @user.id.should == 4
+      expect(@user.id).to eq(4)
     end
   end
 
@@ -163,8 +163,8 @@ describe Her::Model::Relation do
       end
 
       it "should apply the scope to the attributes" do
-        Foo::User.new.should be_active
-        Foo::User.new.should be_admin
+        expect(Foo::User.new).to be_active
+        expect(Foo::User.new).to be_admin
       end
     end
 
@@ -183,7 +183,7 @@ describe Her::Model::Relation do
         end
       end
 
-      it("should apply the scope to the request") { Foo::User.create.should be_active }
+      it("should apply the scope to the request") { expect(Foo::User.create).to be_active }
     end
 
     context "for fetched collections" do
@@ -201,7 +201,7 @@ describe Her::Model::Relation do
         end
       end
 
-      it("should apply the scope to the request") { Foo::User.all.first.should be_active }
+      it("should apply the scope to the request") { expect(Foo::User.all.first).to be_active }
     end
   end
 
@@ -220,7 +220,7 @@ describe Her::Model::Relation do
     end
 
     it "delegates the method to the fetched collection" do
-      Foo::User.all.map(&:fullname).should == ["Tobias Fünke", "Lindsay Fünke"]
+      expect(Foo::User.all.map(&:fullname)).to eq(["Tobias Fünke", "Lindsay Fünke"])
     end
   end
 end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -5,22 +5,22 @@ describe Her::Model::Relation do
   describe :where do
     context "for base classes" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?foo=1&bar=2") { |env| ok! [{ :id => 2, :fullname => "Tobias Fünke" }] }
-            stub.get("/users?admin=1") { |env| ok! [{ :id => 1, :fullname => "Tobias Fünke" }] }
+            stub.get("/users?foo=1&bar=2") { |env| ok! [{ id: 2, fullname: "Tobias Fünke" }] }
+            stub.get("/users?admin=1") { |env| ok! [{ id: 1, fullname: "Tobias Fünke" }] }
 
             stub.get("/users") do |env|
               ok! [
-                { :id => 1, :fullname => "Tobias Fünke" },
-                { :id => 2, :fullname => "Lindsay Fünke" },
+                { id: 1, fullname: "Tobias Fünke" },
+                { id: 2, fullname: "Lindsay Fünke" },
                 @created_user,
               ].compact
             end
 
             stub.post('/users') do |env|
-              @created_user = { :id => 3, :fullname => 'George Michael Bluth' }
+              @created_user = { id: 3, fullname: 'George Michael Bluth' }
               ok! @created_user
             end
           end
@@ -31,39 +31,39 @@ describe Her::Model::Relation do
 
       it "doesn't fetch the data immediatly" do
         expect(Foo::User).to receive(:request).never
-        @users = Foo::User.where(:admin => 1)
+        @users = Foo::User.where(admin: 1)
       end
 
       it "fetches the data and passes query parameters" do
         expect(Foo::User).to receive(:request).once.and_call_original
-        @users = Foo::User.where(:admin => 1)
+        @users = Foo::User.where(admin: 1)
         expect(@users).to respond_to(:length)
         expect(@users.size).to eql 1
       end
 
       it "chains multiple where statements" do
-        @user = Foo::User.where(:foo => 1).where(:bar => 2).first
+        @user = Foo::User.where(foo: 1).where(bar: 2).first
         expect(@user.id).to eq(2)
       end
 
       it "does not reuse relations" do
         expect(Foo::User.all.size).to eql 2
-        expect(Foo::User.create(:fullname => 'George Michael Bluth').id).to eq(3)
+        expect(Foo::User.create(fullname: 'George Michael Bluth').id).to eq(3)
         expect(Foo::User.all.size).to eql 3
       end
     end
 
     context "for parent class" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.adapter :test do |stub|
-            stub.get("/users?page=2") { |env| ok! [{ :id => 1, :fullname => "Tobias Fünke" }, { :id => 2, :fullname => "Lindsay Fünke" }] }
+            stub.get("/users?page=2") { |env| ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }] }
           end
         end
 
         spawn_model("Foo::Model") do
-          scope :page, lambda { |page| where(:page => page) }
+          scope :page, lambda { |page| where(page: page) }
         end
 
         class User < Foo::Model; end
@@ -79,11 +79,11 @@ describe Her::Model::Relation do
 
   describe :create do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.post("/users") { |env| ok! :id => 1, :fullname => params(env)[:fullname], :email => params(env)[:email] }
+          stub.post("/users") { |env| ok! id: 1, fullname: params(env)[:fullname], email: params(env)[:email] }
         end
       end
 
@@ -92,7 +92,7 @@ describe Her::Model::Relation do
 
     context "with a single where call" do
       it "creates a resource and passes the query parameters" do
-        @user = Foo::User.where(:fullname => "Tobias Fünke", :email => "tobias@bluth.com").create
+        @user = Foo::User.where(fullname: "Tobias Fünke", email: "tobias@bluth.com").create
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
         expect(@user.email).to eq("tobias@bluth.com")
@@ -101,7 +101,7 @@ describe Her::Model::Relation do
 
     context "with multiple where calls" do
       it "creates a resource and passes the query parameters" do
-        @user = Foo::User.where(:fullname => "Tobias Fünke").create(:email => "tobias@bluth.com")
+        @user = Foo::User.where(fullname: "Tobias Fünke").create(email: "tobias@bluth.com")
         expect(@user.id).to eq(1)
         expect(@user.fullname).to eq("Tobias Fünke")
         expect(@user.email).to eq("tobias@bluth.com")
@@ -113,7 +113,7 @@ describe Her::Model::Relation do
     before { spawn_model "Foo::User" }
 
     it "handles new resource with build" do
-      @new_user = Foo::User.where(:fullname => "Tobias Fünke").build
+      @new_user = Foo::User.where(fullname: "Tobias Fünke").build
       expect(@new_user.new?).to be_truthy
       expect(@new_user.fullname).to eq("Tobias Fünke")
     end
@@ -121,18 +121,18 @@ describe Her::Model::Relation do
 
   describe :scope do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
-          stub.get("/users?what=4&where=3") { |env| ok! [{ :id => 3, :fullname => "Maeby Fünke" }] }
-          stub.get("/users?what=2") { |env| ok! [{ :id => 2, :fullname => "Lindsay Fünke" }] }
-          stub.get("/users?where=6") { |env| ok! [{ :id => 4, :fullname => "Tobias Fünke" }] }
+          stub.get("/users?what=4&where=3") { |env| ok! [{ id: 3, fullname: "Maeby Fünke" }] }
+          stub.get("/users?what=2") { |env| ok! [{ id: 2, fullname: "Lindsay Fünke" }] }
+          stub.get("/users?where=6") { |env| ok! [{ id: 4, fullname: "Tobias Fünke" }] }
         end
       end
 
       spawn_model 'Foo::User' do
-        scope :foo, lambda { |v| where(:what => v) }
-        scope :bar, lambda { |v| where(:where => v) }
+        scope :foo, lambda { |v| where(what: v) }
+        scope :bar, lambda { |v| where(where: v) }
         scope :baz, lambda { bar(6) }
       end
     end
@@ -157,8 +157,8 @@ describe Her::Model::Relation do
     context "for new objects" do
       before do
         spawn_model 'Foo::User' do
-          default_scope lambda { where(:active => true) }
-          default_scope lambda { where(:admin => true) }
+          default_scope lambda { where(active: true) }
+          default_scope lambda { where(admin: true) }
         end
       end
 
@@ -170,16 +170,16 @@ describe Her::Model::Relation do
 
     context "for fetched resources" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.post("/users") { |env| ok! :id => 3, :active => (params(env)[:active] == "true" ? true : false) }
+            stub.post("/users") { |env| ok! id: 3, active: (params(env)[:active] == "true" ? true : false) }
           end
         end
 
         spawn_model 'Foo::User' do
-          default_scope lambda { where(:active => true) }
+          default_scope lambda { where(active: true) }
         end
       end
 
@@ -188,16 +188,16 @@ describe Her::Model::Relation do
 
     context "for fetched collections" do
       before do
-        Her::API.setup :url => "https://api.example.com" do |builder|
+        Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
-            stub.get("/users?active=true") { |env| ok! [{ :id => 3, :active => (params(env)[:active] == "true" ? true : false) }] }
+            stub.get("/users?active=true") { |env| ok! [{ id: 3, active: (params(env)[:active] == "true" ? true : false) }] }
           end
         end
 
         spawn_model 'Foo::User' do
-          default_scope lambda { where(:active => true) }
+          default_scope lambda { where(active: true) }
         end
       end
 
@@ -207,11 +207,11 @@ describe Her::Model::Relation do
 
   describe :map do
     before do
-      Her::API.setup :url => "https://api.example.com" do |builder|
+      Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.adapter :test do |stub|
           stub.get("/users") do |env|
-            ok! [{ :id => 1, :fullname => "Tobias Fünke" }, { :id => 2, :fullname => "Lindsay Fünke" }]
+            ok! [{ id: 1, fullname: "Tobias Fünke" }, { id: 2, fullname: "Lindsay Fünke" }]
           end
         end
       end

--- a/spec/model/validations_spec.rb
+++ b/spec/model/validations_spec.rb
@@ -35,7 +35,7 @@ describe "Her::Model and ActiveModel::Validations" do
     end
 
     it "validates attributes when calling #valid?" do
-      user = User.new(:_errors => ["Email cannot be blank"])
+      user = User.new(_errors: ["Email cannot be blank"])
       expect(user.errors).to include("Email cannot be blank")
     end
   end

--- a/spec/model/validations_spec.rb
+++ b/spec/model/validations_spec.rb
@@ -13,12 +13,12 @@ describe "Her::Model and ActiveModel::Validations" do
 
     it "validates attributes when calling #valid?" do
       user = Foo::User.new
-      user.should_not be_valid
-      user.errors.full_messages.should include("Fullname can't be blank")
-      user.errors.full_messages.should include("Email can't be blank")
+      expect(user).not_to be_valid
+      expect(user.errors.full_messages).to include("Fullname can't be blank")
+      expect(user.errors.full_messages).to include("Email can't be blank")
       user.fullname = "Tobias Fünke"
       user.email = "tobias@bluthcompany.com"
-      user.should be_valid
+      expect(user).to be_valid
     end
   end
 
@@ -36,7 +36,7 @@ describe "Her::Model and ActiveModel::Validations" do
 
     it "validates attributes when calling #valid?" do
       user = User.new(:_errors => ["Email cannot be blank"])
-      user.errors.should include("Email cannot be blank")
+      expect(user.errors).to include("Email cannot be blank")
     end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 
 describe Her::Model do
   before do
-    Her::API.setup :url => "https://api.example.com" do |connection|
+    Her::API.setup url: "https://api.example.com" do |connection|
       connection.use Her::Middleware::FirstLevelParseJSON
       connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { :id => 1, :name => "Tobias Fünke" }.to_json] }
-        stub.get("/users/1/comments") { |env| [200, {}, [{ :id => 4, :body => "They're having a FIRESALE?" }].to_json] }
+        stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+        stub.get("/users/1/comments") { |env| [200, {}, [{ id: 4, body: "They're having a FIRESALE?" }].to_json] }
       end
     end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -6,8 +6,8 @@ describe Her::Model do
     Her::API.setup url: "https://api.example.com" do |connection|
       connection.use Her::Middleware::FirstLevelParseJSON
       connection.adapter :test do |stub|
-        stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
-        stub.get("/users/1/comments") { |_env| [200, {}, [{ id: 4, body: "They're having a FIRESALE?" }].to_json] }
+        stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+        stub.get("/users/1/comments") { [200, {}, [{ id: 4, body: "They're having a FIRESALE?" }].to_json] }
       end
     end
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -17,10 +17,10 @@ describe Her::Model do
   subject { Foo::User.find(1) }
 
   describe :has_key? do
-    it { should_not have_key(:unknown_method_for_a_user) }
-    it { should_not have_key(:unknown_method_for_a_user) }
-    it { should have_key(:name) }
-    it { should have_key(:comments) }
+    it { is_expected.not_to have_key(:unknown_method_for_a_user) }
+    it { is_expected.not_to have_key(:unknown_method_for_a_user) }
+    it { is_expected.to have_key(:name) }
+    it { is_expected.to have_key(:comments) }
   end
 
   describe :serialization do
@@ -30,15 +30,15 @@ describe Her::Model do
 
     it 'should correctly load serialized object' do
        serialized_comments = Marshal.load(Marshal.dump(subject.comments))
-       subject.comments.size.should eq(serialized_comments.size)
-       subject.comments.first.id.should eq(serialized_comments.first.id)
-       subject.comments.first.body.should eq(serialized_comments.first.body)
+       expect(subject.comments.size).to eq(serialized_comments.size)
+       expect(subject.comments.first.id).to eq(serialized_comments.first.id)
+       expect(subject.comments.first.body).to eq(serialized_comments.first.body)
     end
   end
 
   describe :[] do
-    it { should_not have_key(:unknown_method_for_a_user) }
-    specify { subject[:name].should == "Tobias Fünke" }
-    specify { subject[:comments].first.body.should == "They're having a FIRESALE?" }
+    it { is_expected.not_to have_key(:unknown_method_for_a_user) }
+    specify { expect(subject[:name]).to eq("Tobias Fünke") }
+    specify { expect(subject[:comments].first.body).to eq("They're having a FIRESALE?") }
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
-require 'spec_helper'
+require "spec_helper"
 
 describe Her::Model do
   before do
     Her::API.setup url: "https://api.example.com" do |connection|
       connection.use Her::Middleware::FirstLevelParseJSON
       connection.adapter :test do |stub|
-        stub.get("/users/1") { |env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
-        stub.get("/users/1/comments") { |env| [200, {}, [{ id: 4, body: "They're having a FIRESALE?" }].to_json] }
+        stub.get("/users/1") { |_env| [200, {}, { id: 1, name: "Tobias Fünke" }.to_json] }
+        stub.get("/users/1/comments") { |_env| [200, {}, [{ id: 4, body: "They're having a FIRESALE?" }].to_json] }
       end
     end
 
@@ -24,15 +24,15 @@ describe Her::Model do
   end
 
   describe :serialization do
-    it 'should be serialized without an error' do
+    it "should be serialized without an error" do
       expect { Marshal.dump(subject.comments) }.not_to raise_error
     end
 
-    it 'should correctly load serialized object' do
-       serialized_comments = Marshal.load(Marshal.dump(subject.comments))
-       expect(subject.comments.size).to eq(serialized_comments.size)
-       expect(subject.comments.first.id).to eq(serialized_comments.first.id)
-       expect(subject.comments.first.body).to eq(serialized_comments.first.body)
+    it "should correctly load serialized object" do
+      serialized_comments = Marshal.load(Marshal.dump(subject.comments))
+      expect(subject.comments.size).to eq(serialized_comments.size)
+      expect(subject.comments.first.id).to eq(serialized_comments.first.id)
+      expect(subject.comments.first.body).to eq(serialized_comments.first.body)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require "rspec"
-require "rspec/its"
 require "her"
 
 # Require everything in `spec/support`

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-$:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "..", "lib")
 
 require "rspec"
 require "her"
 
 # Require everything in `spec/support`
-Dir[File.expand_path('../../spec/support/**/*.rb', __FILE__)].map(&method(:require))
+Dir[File.expand_path("../../spec/support/**/*.rb", __FILE__)].map(&method(:require))
 
 # Remove ActiveModel deprecation message
 I18n.enforce_available_locales = false

--- a/spec/support/macros/model_macros.rb
+++ b/spec/support/macros/model_macros.rb
@@ -3,7 +3,7 @@ module Her
     module Macros
       module ModelMacros
         # Create a class and automatically inject Her::Model into it
-        def spawn_model(klass, options={}, &block)
+        def spawn_model(klass, options = {}, &block)
           super_class = options[:super_class]
           model_type = options[:type] || Her::Model
           new_class = if super_class
@@ -12,7 +12,7 @@ module Her
                         Class.new
                       end
           if klass =~ /::/
-            base, submodel = klass.split(/::/).map{ |s| s.to_sym }
+            base, submodel = klass.split(/::/).map(&:to_sym)
             Object.const_set(base, Module.new) unless Object.const_defined?(base)
             Object.const_get(base).module_eval do
               remove_const submodel if constants.map(&:to_sym).include?(submodel)


### PR DESCRIPTION
I've updated the specs to the latest rspec version. Reading them felt a bit painful. I didn't touch anything in 'lib', nor did I make semantic changes to the specs in here. The goal is an update to readability without breaking anything in the process. The big file is just a copy of the default ruby codestyle.

- updated `RSpec` to 3.5
- use ruby 1.9+ hash syntax in specs
- update spec syntax to 3.x using [transpec](https://github.com/yujinakayama/transpec)
- use consistent codestyle throughout the specs using [rubocop](https://github.com/bbatsov/rubocop) ( I went for `"`)

![giphy 1](https://cloud.githubusercontent.com/assets/82336/19008507/ad63d6d6-8763-11e6-8fa2-be4f5835a379.gif)