### PR TITLE
Fixes embedded_params when params are empty

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -58,7 +58,7 @@ module Her
         def embeded_params(attributes)
           associations[:has_many].select { |a| attributes.include?(a[:data_key])}.compact.inject({}) do |hash, association|
             params = attributes[association[:data_key]].map(&:to_params)
-            next if params.empty?
+            next hash if params.empty?
             if association[:class_name].constantize.include_root_in_json?
               root = association[:class_name].constantize.root_element
               hash[association[:data_key]] = params.map { |n| n[root] }


### PR DESCRIPTION
`params` expects `embeded_params` to always return a `Hash`. This fixes an edge case where `embeded_params` can return `nil`, which causes an exception in `merge!`.