### PR TITLE
Handle the destroyed instance variable according to errors

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -80,7 +80,7 @@ module Her
             assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
             @metadata = parsed_data[:metadata]
             @response_errors = parsed_data[:errors]
-            @destroyed = true
+            @destroyed = @response_errors.empty?
           end
         end
         self
@@ -163,7 +163,7 @@ module Her
             data = parse(parsed_data[:data])
             metadata = parsed_data[:metadata]
             response_errors = parsed_data[:errors]
-            new(data.merge(:_destroyed => true, :metadata => metadata, :response_errors => response_errors))
+            new(data.merge(:_destroyed => response_errors.empty?, :metadata => metadata, :response_errors => response_errors))
           end
         end
 

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -80,7 +80,7 @@ module Her
             assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?
             @metadata = parsed_data[:metadata]
             @response_errors = parsed_data[:errors]
-            @destroyed = @response_errors.empty?
+            @destroyed = response.success?
           end
         end
         self
@@ -163,7 +163,7 @@ module Her
             data = parse(parsed_data[:data])
             metadata = parsed_data[:metadata]
             response_errors = parsed_data[:errors]
-            new(data.merge(:_destroyed => response_errors.empty?, :metadata => metadata, :response_errors => response_errors))
+            new(data.merge(:_destroyed => response.success?, :metadata => metadata, :response_errors => response_errors))
           end
         end
 

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -400,15 +400,14 @@ describe Her::Model::ORM do
   end
 
   context "deleting resources" do
-    let(:errors) { [] }
-    let(:active) { false }
+    let(:status) { 200 }
     before do
       Her::API.setup url: "https://api.example.com" do |builder|
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
           stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", active: true }.to_json] }
-          stub.delete("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", active: active, errors: errors }.to_json] }
+          stub.delete("/users/1") { [status, {}, { id: 1, fullname: "Lindsay Fünke", active: false }.to_json] }
         end
       end
 
@@ -429,22 +428,16 @@ describe Her::Model::ORM do
     end
 
     context "with response_errors" do
-      let(:errors) { ["Failed to delete"] }
-      let(:active) { true }
-
+      let(:status) { 422 }
       it "set user.destroyed to false if errors are present through the .destroy class method" do
         @user = Foo::User.destroy_existing(1)
-        expect(@user.response_errors).to eq(["Failed to delete"])
         expect(@user).not_to be_destroyed
-        expect(@user.active).to be_truthy
       end
 
       it "set user.destroyed to false if errors are present through #destroy on an existing resource" do
         @user = Foo::User.find(1)
         @user.destroy
-        expect(@user.response_errors).to eq(["Failed to delete"])
         expect(@user).not_to be_destroyed
-        expect(@user.active).to be_truthy
       end
     end
 


### PR DESCRIPTION
The presence of response_errors for a destroy request indicates the
request has not been successful, e.g. due to authorisation issues. By
returning a truthy value a false indication is given as we cannot
assume everyone checking for response errors.

I therefore relate the value of ```@destroyed``` to the existence of errors
as it seems more sensible to me.

Looking forward to your comments. Especially since this may be a
breaking change for some users.