### PR TITLE
Fix the TypeError exception when primary key is given to `#where` 

### DIFF
--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -65,7 +65,7 @@ module Her
       # @private
       def fetch
         @_fetch ||= begin
-          path = @parent.build_request_path(@params)
+          path = @parent.build_request_path(@parent.collection_path, @params)
           method = @parent.method_for(:find)
           @parent.request(@params.merge(:_method => method, :_path => path)) do |parsed_data, response|
             @parent.new_collection(parsed_data)

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -10,7 +10,7 @@ describe Her::Model::Relation do
           builder.adapter :test do |stub|
             stub.get("/users?foo=1&bar=2") { ok! [{ id: 2, fullname: "Tobias Fünke" }] }
             stub.get("/users?admin=1") { ok! [{ id: 1, fullname: "Tobias Fünke" }] }
-            stub.get("/users?id=3&foo=2") { ok! [{ id: 3, fullname: "Tobias Fünke" }] }
+            stub.get("/users/3?id=3&foo=2") { ok!(id: 3, fullname: "Tobias Fünke") }
 
             stub.get("/users") do
               ok! [

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -10,7 +10,7 @@ describe Her::Model::Relation do
           builder.adapter :test do |stub|
             stub.get("/users?foo=1&bar=2") { ok! [{ id: 2, fullname: "Tobias Fünke" }] }
             stub.get("/users?admin=1") { ok! [{ id: 1, fullname: "Tobias Fünke" }] }
-            stub.get("/users/3?id=3&foo=2") { ok!(id: 3, fullname: "Tobias Fünke") }
+            stub.get("/users?id=3&foo=2") { ok! [{ id: 3, fullname: "Tobias Fünke" }] }
 
             stub.get("/users") do
               ok! [

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -10,6 +10,7 @@ describe Her::Model::Relation do
           builder.adapter :test do |stub|
             stub.get("/users?foo=1&bar=2") { ok! [{ id: 2, fullname: "Tobias Fünke" }] }
             stub.get("/users?admin=1") { ok! [{ id: 1, fullname: "Tobias Fünke" }] }
+            stub.get("/users?id=3&foo=2") { ok! [{ id: 3, fullname: "Tobias Fünke" }] }
 
             stub.get("/users") do
               ok! [
@@ -37,6 +38,13 @@ describe Her::Model::Relation do
       it "fetches the data and passes query parameters" do
         expect(Foo::User).to receive(:request).once.and_call_original
         @users = Foo::User.where(admin: 1)
+        expect(@users).to respond_to(:length)
+        expect(@users.size).to eql 1
+      end
+
+      it "fetches the data by parameters including primary_key" do
+        expect(Foo::User).to receive(:request).once.and_call_original
+        @users = Foo::User.where(id: 3, foo: 2)
         expect(@users).to respond_to(:length)
         expect(@users.size).to eql 1
       end


### PR DESCRIPTION
Hi. `#where` with parameters including primary key seems does not work. A reproducible failed test code is include in this pull request.

```
e.g.) Foo::User.where(id: 3, foo: 2).first #=>

     TypeError:
       no implicit conversion of Array into Hash
     # ./lib/her/model/relation.rb:15:in `merge'
     # ./lib/her/model/relation.rb:15:in `apply_to'
     # ./lib/her/model/attributes.rb:26:in `initialize'
     # ./lib/her/model/attributes.rb:39:in `new'
     # ./lib/her/model/attributes.rb:39:in `block in initialize_collection'
     # ./lib/her/model/attributes.rb:35:in `each'
     # ./lib/her/model/attributes.rb:35:in `map'
     # ./lib/her/model/attributes.rb:35:in `initialize_collection'
     # ./lib/her/model/attributes.rb:183:in `new_collection'
     # ./lib/her/model/relation.rb:71:in `block in fetch'
     # ./lib/her/model/http.rb:59:in `request'
     # ./lib/her/model/relation.rb:70:in `fetch'
     # ./lib/her/model/relation.rb:50:in `respond_to?'
```

I think it should fetch a collection path with query `?{primary key}=xxx` , but it fetches a resource path now so the above error comes on the phase of building collection instance from parsed response.