### PR TITLE
add reload to model

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -86,6 +86,23 @@ module Her
         self
       end
 
+      # Refetches the resource
+      #
+      # This method finds the resource by its primary key (which could be
+      # assigned manually) and modifies the object in-place.
+      #
+      # @example
+      #   user = User.find(1)
+      #   # => #<User(users/1) id=1 name="Tobias Fünke">
+      #   user.name = "Oops"
+      #   user.reload # Fetched again via GET "/users/1"
+      #   # => #<User(users/1) id=1 name="Tobias Fünke">
+      def reload(options = nil)
+        fresh_object = self.class.find(id)
+        assign_attributes(fresh_object.attributes)
+        self
+      end
+
       module ClassMethods
         # Create a new chainable scope
         #

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -275,6 +275,14 @@ describe Her::Model::ORM do
       expect(@users.where(age: 42)).to be_all { |u| u.age == 42 }
       expect(@users.where(age: 40)).to be_all { |u| u.age == 40 }
     end
+
+    it "handles reloading a resource" do
+      @user = User.find(1)
+      @user.age = "Oops"
+      @user.reload
+      expect(@user.age).to eq 42
+      expect(@user).to be_persisted
+    end
   end
 
   context "building resources" do


### PR DESCRIPTION
Similar to [ActiveRecord::Persistence.reload](https://apidock.com/rails/ActiveRecord/Persistence/reload), this will refetch a resource from the API and assign its attributes in-place.

```ruby
user = User.find(1)
# => #<User(users/1) id=1 name="Tobias Fünke">
user.name = "Oops"
user.reload # Fetched again via GET "/users/1"
# => #<User(users/1) id=1 name="Tobias Fünke">
```
As described in the docs
> Reloading is commonly used in test suites to test something is actually
> written to the database, or when some action modifies the corresponding
> row in the database but not the object in memory

It's useful in the console as well.

fyi PR #367 also adds `reload` to associations 😺