### PR TITLE
add toggle and toggle! to model

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -103,6 +103,27 @@ module Her
         self
       end
 
+      # Assigns to +attribute+ the boolean opposite of <tt>attribute?</tt>. So
+      # if the predicate returns +true+ the attribute will become +false+. This
+      # method toggles directly the underlying value without calling any setter.
+      # Returns +self+.
+      #
+      # @example
+      #   user = User.first
+      #   user.admin? # => false
+      #   user.toggle(:admin)
+      #   user.admin? # => true
+      def toggle(attribute)
+        attributes[attribute] = !public_send("#{attribute}?")
+        self
+      end
+
+      # Wrapper around #toggle that saves the resource. Saving is subjected to
+      # validation checks. Returns +true+ if the record could be saved.
+      def toggle!(attribute)
+        toggle(attribute) && save
+      end
+
       module ClassMethods
         # Create a new chainable scope
         #

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -379,8 +379,8 @@ describe Her::Model::ORM do
         builder.use Her::Middleware::FirstLevelParseJSON
         builder.use Faraday::Request::UrlEncoded
         builder.adapter :test do |stub|
-          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke" }.to_json] }
-          stub.put("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke" }.to_json] }
+          stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", admin: false }.to_json] }
+          stub.put("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", admin: true }.to_json] }
         end
       end
 
@@ -404,6 +404,22 @@ describe Her::Model::ORM do
       @user.fullname = "Lindsay Fünke"
       @user.save
       expect(@user.fullname).to eq("Lindsay Fünke")
+    end
+
+    it "handles resource update through #toggle without saving it" do
+      @user = Foo::User.find(1)
+      expect(@user.admin).to be_falsey
+      expect(@user).to_not receive(:save)
+      @user.toggle(:admin)
+      expect(@user.admin).to be_truthy
+    end
+
+    it "handles resource update through #toggle!" do
+      @user = Foo::User.find(1)
+      expect(@user.admin).to be_falsey
+      expect(@user).to receive(:save).and_return(true)
+      @user.toggle!(:admin)
+      expect(@user.admin).to be_truthy
     end
   end
 


### PR DESCRIPTION
Similar to [ActiveRecord::Persistence.toggle](https://apidock.com/rails/ActiveRecord/Persistence/toggle), this will assign to `attribute` the boolean opposite of `attribute?` without calling save. There's also a `toggle!` version which saves the resource afterwards.

```ruby
user = User.first # => #<User(users/1) id=1 admin=false>
user.admin? # => false
user.toggle(:admin)
user.admin? # => true

user.reload.admin? # => false
user.toggle!(:admin) # => true
# Saved via PUT "/users/1"
user.admin? # => true
```