### PR TITLE
add increment, increment!, decrement and decrement! to model

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -124,6 +124,37 @@ module Her
         toggle(attribute) && save
       end
 
+      # Initializes +attribute+ to zero if +nil+ and adds the value passed as
+      # +by+ (default is 1). The increment is performed directly on the
+      # underlying attribute, no setter is invoked. Only makes sense for
+      # number-based attributes. Returns +self+.
+      def increment(attribute, by = 1)
+        attributes[attribute] ||= 0
+        attributes[attribute] += by
+        self
+      end
+
+      # Wrapper around #increment that saves the resource. Saving is subjected
+      # to validation checks. Returns +self+.
+      def increment!(attribute, by = 1)
+        increment(attribute, by) && save
+        self
+      end
+
+      # Initializes +attribute+ to zero if +nil+ and substracts the value passed as
+      # +by+ (default is 1). The decrement is performed directly on the
+      # underlying attribute, no setter is invoked. Only makes sense for
+      # number-based attributes. Returns +self+.
+      def decrement(attribute, by = 1)
+        increment(attribute, -by)
+      end
+
+      # Wrapper around #decrement that saves the resource. Saving is subjected
+      # to validation checks. Returns +self+.
+      def decrement!(attribute, by = 1)
+        increment!(attribute, -by)
+      end
+
       module ClassMethods
         # Create a new chainable scope
         #

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -381,10 +381,13 @@ describe Her::Model::ORM do
         builder.adapter :test do |stub|
           stub.get("/users/1") { [200, {}, { id: 1, fullname: "Tobias Fünke", admin: false }.to_json] }
           stub.put("/users/1") { [200, {}, { id: 1, fullname: "Lindsay Fünke", admin: true }.to_json] }
+          stub.get("/pages/1") { [200, {}, { id: 1, views: 1, unique_visitors: 4 }.to_json] }
+          stub.put("/pages/1") { [200, {}, { id: 1, views: 2, unique_visitors: 3 }.to_json] }
         end
       end
 
       spawn_model "Foo::User"
+      spawn_model "Foo::Page"
     end
 
     it "handle resource data update without saving it" do
@@ -420,6 +423,42 @@ describe Her::Model::ORM do
       expect(@user).to receive(:save).and_return(true)
       @user.toggle!(:admin)
       expect(@user.admin).to be_truthy
+    end
+
+    it "handles resource update through #increment without saving it" do
+      page = Foo::Page.find(1)
+      expect(page.views).to be 1
+      expect(page).to_not receive(:save)
+      page.increment(:views)
+      expect(page.views).to be 2
+      page.increment(:views, 2)
+      expect(page.views).to be 4
+    end
+
+    it "handles resource update through #increment!" do
+      page = Foo::Page.find(1)
+      expect(page.views).to be 1
+      expect(page).to receive(:save).and_return(true)
+      page.increment!(:views)
+      expect(page.views).to be 2
+    end
+
+    it "handles resource update through #decrement without saving it" do
+      page = Foo::Page.find(1)
+      expect(page.unique_visitors).to be 4
+      expect(page).to_not receive(:save)
+      page.decrement(:unique_visitors)
+      expect(page.unique_visitors).to be 3
+      page.decrement(:unique_visitors, 2)
+      expect(page.unique_visitors).to be 1
+    end
+
+    it "handles resource update through #decrement!" do
+      page = Foo::Page.find(1)
+      expect(page.unique_visitors).to be 4
+      expect(page).to receive(:save).and_return(true)
+      page.decrement!(:unique_visitors)
+      expect(page.unique_visitors).to be 3
     end
   end
 


### PR DESCRIPTION
Similar to [ActiveRecord::Persistence.increment](https://apidock.com/rails/v4.2.7/ActiveRecord/Persistence/increment) and [decrement](https://apidock.com/rails/v4.2.7/ActiveRecord/Persistence/decrement), this will add or subtract the value passed as `by` (default is 1) without calling save. There's also corresponding `increment!` and `decrement!` versions which save the resource afterwards.

```ruby
page = Page.first # => #<Page(pages/1) id=1 views=5>
page.views # => 5
page.increment(:views)
page.views # => 6
page.increment(:views, 4)
page.views # => 10

page.reload.views # => 5
page.increment!(:views) # Saved via PUT "/pages/1"
page.views # => 6
page.decrement!(:views) # Saved via PUT "/pages/1"
page.views # => 5
```