### PR TITLE
add find_by, find_or_create_by, find_or_initialize_by to relation

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -151,7 +151,8 @@ module Her
         end
 
         # Delegate the following methods to `scoped`
-        [:all, :where, :create, :build, :find, :first_or_create, :first_or_initialize].each do |method|
+        [:all, :where, :create, :build, :find, :find_by, :find_or_create_by,
+         :find_or_initialize_by, :first_or_create, :first_or_initialize].each do |method|
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{method}(*params)
               scoped.send(#{method.to_sym.inspect}, *params)

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -109,6 +109,50 @@ module Her
         ids.length > 1 || ids.first.kind_of?(Array) ? results : results.first
       end
 
+      # Fetch first resource with the given attributes.
+      #
+      # If no resource is found, returns <tt>nil</tt>.
+      #
+      # @example
+      #   @user = User.find_by(name: "Tobias", age: 42)
+      #   # Called via GET "/users?name=Tobias&age=42"
+      def find_by(params)
+        where(params).first
+      end
+
+      # Fetch first resource with the given attributes, or create a resource
+      # with the attributes if one is not found.
+      #
+      # @example
+      #   @user = User.find_or_create_by(email: "remi@example.com")
+      #
+      #   # Returns the first item in the collection if present:
+      #   # Called via GET "/users?email=remi@example.com"
+      #
+      #   # If collection is empty:
+      #   # POST /users with `email=remi@example.com`
+      #   @user.email # => "remi@example.com"
+      #   @user.new? # => false
+      def find_or_create_by(attributes)
+        find_by(attributes) || create(attributes)
+      end
+
+      # Fetch first resource with the given attributes, or initialize a resource
+      # with the attributes if one is not found.
+      #
+      # @example
+      #   @user = User.find_or_initialize_by(email: "remi@example.com")
+      #
+      #   # Returns the first item in the collection if present:
+      #   # Called via GET "/users?email=remi@example.com"
+      #
+      #   # If collection is empty:
+      #   @user.email # => "remi@example.com"
+      #   @user.new? # => true
+      def find_or_initialize_by(attributes)
+        find_by(attributes) || build(attributes)
+      end
+
       # Create a resource and return it
       #
       # @example

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -212,6 +212,8 @@ describe Her::Model::ORM do
           stub.get("/users?age=42&foo=bar") { [200, {}, [{ id: 3, age: 42 }].to_json] }
           stub.get("/users?age=42") { [200, {}, [{ id: 1, age: 42 }].to_json] }
           stub.get("/users?age=40") { [200, {}, [{ id: 1, age: 40 }].to_json] }
+          stub.get("/users?name=baz") { [200, {}, [].to_json] }
+          stub.post("/users") { [200, {}, { id: 5, name: "baz" }.to_json] }
         end
       end
 
@@ -262,6 +264,24 @@ describe Her::Model::ORM do
       expect(@users.length).to eq(2)
       expect(@users[0].id).to eq(1)
       expect(@users[1].id).to eq(2)
+    end
+
+    it "handles finding by attributes" do
+      @user = User.find_by(age: 42)
+      expect(@user).to be_a(User)
+      expect(@user.id).to eq(1)
+    end
+
+    it "handles find or create by attributes" do
+      @user = User.find_or_create_by(name: "baz")
+      expect(@user).to be_a(User)
+      expect(@user.id).to eq(5)
+    end
+
+    it "handles find or initialize by attributes" do
+      @user = User.find_or_initialize_by(name: "baz")
+      expect(@user).to be_a(User)
+      expect(@user).to_not be_persisted
     end
 
     it "handles finding with other parameters" do


### PR DESCRIPTION
Similar to ActiveRecord [find_by](https://apidock.com/rails/v4.2.7/ActiveRecord/FinderMethods/find_by), [find_or_create_by](https://apidock.com/rails/v4.2.7/ActiveRecord/Relation/find_or_create_by), and [find_or_initialize_by](https://apidock.com/rails/v4.2.7/ActiveRecord/Relation/find_or_initialize_by), these methods will find the first resource matching the specified conditions and create or initialize one if it doesn't exist 😺 

```ruby
user = User.find_by(name: "Tobias", age: 42) 
# => Called via GET "/users?name=Tobias&age=42"
#<User(users/1) id=1 name="Tobias" age=42>

user = User.find_or_create_by(name: "new_user") 
# => Called via GET "/users?name=new_user"
# => POST /users with `name=new_user`
user.name # => "new_user"
user.persisted? # => true

user = User.find_or_initialize_by(name: "new_user") 
# => Called via GET "/users?name=new_user"
user.name # => "new_user"
user.persisted? # => false
```

We currently have `first_or_create` and `first_or_initialize` but there are [subtle differences](https://chodounsky.net/2015/09/14/create-record-if-it-does-not-exist-in-activerecord/) between these methods and their `find_by` counterparts.  For example, `first_or_create` returns the first record using the current scope and not the attributes passed to it.

```ruby
user = User.first_or_create(name: "Tobias") 
# => Called via GET "/users"

user = User.find_or_create_by(name: "Tobias") 
# => Called via GET "/users?name=Tobias"
```