### PR TITLE
Add `key_transform :dash` for JSON API

### DIFF
--- a/lib/her/json_api/model.rb
+++ b/lib/her/json_api/model.rb
@@ -18,13 +18,13 @@ module Her
           
           def self.parse(data)
             if key_transform?
-              data.fetch(:attributes).merge(data.slice(:id)).transform_keys do |key|
+              data.fetch(:attributes).merge(data.slice(:id)).inject({}) do |hash, (key, value)|
                 case key_transform
                 when :dash
-                  key.to_s.tr("-".freeze, "_".freeze).to_sym
-                else
-                  key
+                  key = key.to_s.tr("-".freeze, "_".freeze).to_sym
                 end
+                hash[key] = value
+                hash
               end
             else
               data.fetch(:attributes).merge(data.slice(:id))
@@ -42,13 +42,13 @@ module Her
                 end
 
                 if key_transform?
-                  filtered_attributes.transform_keys! do |key|
+                  filtered_attributes.keys.each do |key|
+                    value = filtered_attributes.delete(key)
                     case key_transform
                     when :dash
-                      key.to_s.tr("_".freeze, "-".freeze).to_sym
-                    else
-                      key
+                      key = key.to_s.tr("_".freeze, "-".freeze).to_sym
                     end
+                    filtered_attributes[key] = value
                   end
                 end
               }

--- a/lib/her/json_api/model.rb
+++ b/lib/her/json_api/model.rb
@@ -17,7 +17,18 @@ module Her
           @type = name.demodulize.tableize
           
           def self.parse(data)
-            data.fetch(:attributes).merge(data.slice(:id))
+            if key_transform?
+              data.fetch(:attributes).merge(data.slice(:id)).transform_keys do |key|
+                case key_transform
+                when :underscore
+                  key.to_s.tr("-".freeze, "_".freeze).to_sym
+                else
+                  key
+                end
+              end
+            else
+              data.fetch(:attributes).merge(data.slice(:id))
+            end
           end
 
           def self.to_params(attributes, changes={})
@@ -27,6 +38,17 @@ module Her
                   filtered_attributes = changes.symbolize_keys.keys.inject({}) do |hash, attribute|
                     hash[attribute] = filtered_attributes[attribute]
                     hash
+                  end
+                end
+
+                if key_transform?
+                  filtered_attributes.transform_keys! do |key|
+                    case key_transform
+                    when :underscore
+                      key.to_s.tr("_".freeze, "-".freeze).to_sym
+                    else
+                      key
+                    end
                   end
                 end
               }

--- a/lib/her/json_api/model.rb
+++ b/lib/her/json_api/model.rb
@@ -20,7 +20,7 @@ module Her
             if key_transform?
               data.fetch(:attributes).merge(data.slice(:id)).transform_keys do |key|
                 case key_transform
-                when :underscore
+                when :dash
                   key.to_s.tr("-".freeze, "_".freeze).to_sym
                 else
                   key
@@ -44,7 +44,7 @@ module Her
                 if key_transform?
                   filtered_attributes.transform_keys! do |key|
                     case key_transform
-                    when :underscore
+                    when :dash
                       key.to_s.tr("_".freeze, "-".freeze).to_sym
                     else
                       key

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -137,6 +137,27 @@ module Her
           end
         end
 
+        # Transform attribute keys to and from the API.
+        #
+        # @param [Symbol] option The option configuring how keys are modified (`:underscore` will replace `example-key` in JSON API with `example_key` in Rails)
+        #
+        # @example
+        #   class User
+        #     include Her::Model
+        #     key_transform :underscore
+        #     user = User.find(1)
+        #     user.full_name # Get the value of `full-name` key
+        #   end
+        #
+        def key_transform(value = nil)
+          @_her_key_transform = value || @_her_key_transform
+        end
+
+        # @private
+        def key_transform?
+          @_her_key_transform || (superclass.respond_to?(:key_transform?) && superclass.key_transform?)
+        end
+
         # @private
         def root_element_included?(data)
           data.keys.to_s.include? @_her_root_element.to_s

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -137,14 +137,15 @@ module Her
           end
         end
 
-        # Transform attribute keys to and from the API.
+        # Transform attributes keys during (de)serialization.
+        # This allow the transformation of any underscore contained in ruby symbols into dash to fit JSON API format.
         #
-        # @param [Symbol] option The option configuring how keys are modified (`:underscore` will replace `example-key` in JSON API with `example_key` in Rails)
+        # @param [Symbol] option The option configuring how keys are modified (`:dash` will replace `example_key` with `example-key` during serialization)
         #
         # @example
         #   class User
         #     include Her::Model
-        #     key_transform :underscore
+        #     key_transform :dash
         #     user = User.find(1)
         #     user.full_name # Get the value of `full-name` key
         #   end

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -108,7 +108,7 @@ describe Her::JsonApi::Model do
     end
 
     spawn_model("Foo::User", type: Her::JsonApi::Model) do
-      key_transform :underscore
+      key_transform :dash
     end
   end
 

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -15,7 +15,7 @@ describe Her::JsonApi::Model do
                 type: "users",
                 attributes: {
                   name: "Roger Federer",
-                  "first-name": "Roger"
+                  :"first-name" => "Roger"
                 }
               }
 
@@ -34,7 +34,7 @@ describe Her::JsonApi::Model do
                   type: "users",
                   attributes: {
                     name: "Roger Federer",
-                    "first-name": "Roger"
+                    :"first-name" => "Roger"
                   }
                 },
                 {
@@ -42,7 +42,7 @@ describe Her::JsonApi::Model do
                   type: "users",
                   attributes: {
                     name: "Kei Nishikori",
-                    "first-name": "Kei"
+                    :"first-name" => "Kei"
                   }
                 }
               ]
@@ -55,7 +55,7 @@ describe Her::JsonApi::Model do
           type: "users",
           attributes: {
             name: "Jeremy Lin",
-            "first-name": "Jeremy"
+            :"first-name" => "Jeremy"
           }
         }) do
           [
@@ -67,7 +67,7 @@ describe Her::JsonApi::Model do
                 type: "users",
                 attributes: {
                   name: "Jeremy Lin",
-                  "first-name": "Jeremy"
+                  :"first-name" => "Jeremy"
                 }
               }
 
@@ -81,7 +81,7 @@ describe Her::JsonApi::Model do
           id: 1,
           attributes: {
             name: "Fed GOAT",
-            "first-name": "Fed"
+            :"first-name" => "Fed"
           }
         }) do
           [
@@ -93,7 +93,7 @@ describe Her::JsonApi::Model do
                 type: "users",
                 attributes: {
                   name: "Fed GOAT",
-                  "first-name": "Fed"
+                  :"first-name" => "Fed"
                 }
               }
 

--- a/spec/json_api/model_spec.rb
+++ b/spec/json_api/model_spec.rb
@@ -14,7 +14,8 @@ describe Her::JsonApi::Model do
                 id:    1,
                 type: "users",
                 attributes: {
-                  name: "Roger Federer"
+                  name: "Roger Federer",
+                  "first-name": "Roger"
                 }
               }
 
@@ -32,14 +33,16 @@ describe Her::JsonApi::Model do
                   id:    1,
                   type: "users",
                   attributes: {
-                    name: "Roger Federer"
+                    name: "Roger Federer",
+                    "first-name": "Roger"
                   }
                 },
                 {
                   id:    2,
                   type: "users",
                   attributes: {
-                    name: "Kei Nishikori"
+                    name: "Kei Nishikori",
+                    "first-name": "Kei"
                   }
                 }
               ]
@@ -51,7 +54,8 @@ describe Her::JsonApi::Model do
         {
           type: "users",
           attributes: {
-            name: "Jeremy Lin"
+            name: "Jeremy Lin",
+            "first-name": "Jeremy"
           }
         }) do
           [
@@ -62,7 +66,8 @@ describe Her::JsonApi::Model do
                 id:    3,
                 type: "users",
                 attributes: {
-                  name: "Jeremy Lin"
+                  name: "Jeremy Lin",
+                  "first-name": "Jeremy"
                 }
               }
 
@@ -75,7 +80,8 @@ describe Her::JsonApi::Model do
           type: "users",
           id: 1,
           attributes: {
-            name: "Fed GOAT"
+            name: "Fed GOAT",
+            "first-name": "Fed"
           }
         }) do
           [
@@ -86,7 +92,8 @@ describe Her::JsonApi::Model do
                 id:    1,
                 type: "users",
                 attributes: {
-                  name: "Fed GOAT"
+                  name: "Fed GOAT",
+                  "first-name": "Fed"
                 }
               }
 
@@ -100,7 +107,9 @@ describe Her::JsonApi::Model do
       end
     end
 
-    spawn_model("Foo::User", type: Her::JsonApi::Model)
+    spawn_model("Foo::User", type: Her::JsonApi::Model) do
+      key_transform :underscore
+    end
   end
 
   it "allows configuration of type" do
@@ -115,7 +124,8 @@ describe Her::JsonApi::Model do
     user = Foo::User.find(1)
     expect(user.attributes).to eql(
       "id" => 1,
-      "name" => "Roger Federer"
+      "name" => "Roger Federer",
+      "first_name" => "Roger"
     )
   end
 
@@ -125,32 +135,37 @@ describe Her::JsonApi::Model do
       [
         {
           "id" => 1,
-          "name" => "Roger Federer"
+          "name" => "Roger Federer",
+          "first_name" => "Roger"
         },
         {
-          "id" => 2,
-          "name" => "Kei Nishikori"
+          id: 2,
+          name: "Kei Nishikori",
+          "first_name" => "Kei"
         }
       ]
     )
   end
 
   it "creates a Foo::User" do
-    user = Foo::User.new(name: "Jeremy Lin")
+    user = Foo::User.new(name: "Jeremy Lin", first_name: "Jeremy")
     user.save
     expect(user.attributes).to eql(
       "id" => 3,
-      "name" => "Jeremy Lin"
+      "name" => "Jeremy Lin",
+      "first_name" => "Jeremy"
     )
   end
 
   it "updates a Foo::User" do
     user = Foo::User.find(1)
     user.name = "Fed GOAT"
+    user.first_name = "Fed"
     user.save
     expect(user.attributes).to eql(
       "id" => 1,
-      "name" => "Fed GOAT"
+      "name" => "Fed GOAT",
+      "first_name" => "Fed"
     )
   end
 


### PR DESCRIPTION
In ruby we use underscore for symbols, but dash are prefered for keys with JSON API.

By default, Active Model Serializers transforms underscore into dash when JSON API is used, otherwise it leaves the keys unaltered: https://github.com/rails-api/active_model_serializers/blob/v0.10.6/docs/general/key_transforms.md

This PR is a request for comments regarding the transformation of keys during serialization and deserialization.

If we have a JSON API exposing a `user` resource with a `first-name` attribute, this allow us to access it by `user.first_name` in Rails if we add `key_transform :dash` to the model.

So far this PR is quite restricted:
- Only JSON API
- Only `:dash` option
- No recursion on the keys of nested attributes

`key_transform` could also be applied to regular APIs, otherwise it should maybe be renommed `json_api_key_transform`?