### PR TITLE
Fix for correct ActiveModel::Dirty #previous_changes implementation

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -49,7 +49,7 @@ module Her
 
               return false if !response.success? || @response_errors.any?
               if self.changed_attributes.present?
-                @previously_changed = self.changed_attributes.clone
+                @previously_changed = self.changes.clone
                 self.changed_attributes.clear
               end
             end

--- a/spec/model/dirty_spec.rb
+++ b/spec/model/dirty_spec.rb
@@ -49,7 +49,7 @@ describe "Her::Model and ActiveModel::Dirty" do
         it "tracks previous changes" do
           user.fullname = "Tobias Fünke"
           user.save
-          expect(user.previous_changes).to eq("fullname" => "Lindsay Fünke")
+          expect(user.previous_changes).to eq("fullname" => ["Lindsay Fünke", "Tobias Fünke"])
         end
 
         it "tracks dirty attribute for mass assign for dynamic created attributes" do


### PR DESCRIPTION
ActiveModel::Dirty specifies that `#previous_changes` should respond with the same output as `#changes` did prior to the save, including both the value of the field before and after the save.  The implementation in Her was responding with `#changed_attributes`, which only gives the original value of the field, not before and after changing.

This should resolve that discrepancy.