### PR TITLE
Revert "adds timeout and open_timeout options for faraday"

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -6,7 +6,7 @@ module Her
     attr_reader :connection, :options
 
     # Constants
-    FARADAY_OPTIONS = [:request, :proxy, :ssl, :builder, :url, :parallel_manager, :params, :headers, :builder_class, :timeout, :open_timeout].freeze
+    FARADAY_OPTIONS = [:request, :proxy, :ssl, :builder, :url, :parallel_manager, :params, :headers, :builder_class].freeze
 
     # Setup a default API connection. Accepted arguments and options are the same as {API#setup}.
     def self.setup(opts={}, &block)


### PR DESCRIPTION
This reverts commit bfa4f11f0eef3c0a3a8310a9b65ae4c169437791.

Believe there's confusion around the `timeout` and `open_timeout` options introduced in #400. These options should be part of the [request hash](https://github.com/lostisland/faraday/blob/a712938071bb0997410b5de4a4f2517d30fc4d3d/lib/faraday/options.rb#L192) set on the connection. There's a [thread](https://github.com/lostisland/faraday/issues/417#issuecomment-223413386) on Faraday w/ more detail.

As far as I can tell `open_timeout` and `timeout` are never recognized by Faraday unless they're part of the request hash, or set on the builder, going as far back as `0.5.7`. The syntax should be

```ruby
Her::API.setup(url: "https://api.example.com", request: { timeout: 10, open_timeout: 2 })
```

As mentioned [elsewhere](https://github.com/remiprev/her/pull/400#issuecomment-275759060) they can also be set through the faraday builder
```ruby
Her::API.setup(url: "https://api.example.com") do |c|
  c.options.timeout = 10
  c.options.open_timeout = 2
end
```