### PR TITLE
accept block with initialize

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -25,6 +25,8 @@ module Her
 
         attributes = self.class.default_scope.apply_to(attributes)
         assign_attributes(attributes)
+
+        yield self if block_given?
         run_callbacks :initialize
       end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -11,6 +11,14 @@ describe Her::Model::Attributes do
       expect(@new_user.fullname).to eq("Tobias Fünke")
     end
 
+    it "handles new resource with block" do
+      @new_user = Foo::User.new do |user|
+        user.fullname = "Tobias Fünke"
+      end
+      expect(@new_user.new?).to be_truthy
+      expect(@new_user.fullname).to eq("Tobias Fünke")
+    end
+
     it "accepts new resource with strings as hash keys" do
       @new_user = Foo::User.new("fullname" => "Tobias Fünke")
       expect(@new_user.fullname).to eq("Tobias Fünke")


### PR DESCRIPTION
Similar to ActiveRecord [initialize](https://apidock.com/rails/v4.2.7/ActiveRecord/Base), this adds block initialization to Her models 😺

```ruby
user = User.new do |u|
  u.name = "David"
  u.occupation = "Software Writer"
end
```