### PR TITLE
refactor of attributes

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -26,11 +26,7 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          if data[data_key].kind_of?(klass)
-            { association[:name] => data[data_key] }
-          else
-            { association[:name] => klass.new(klass.parse(data[data_key])) }
-          end
+          { association[:name] => klass.instantiate_record(klass, data: data[data_key]) }
         end
 
         # @private
@@ -104,7 +100,7 @@ module Her
           @klass.get_resource(path, @params)
         end
 
-        # Refetches the association and puts the proxy back in its initial state, 
+        # Refetches the association and puts the proxy back in its initial state,
         # which is unloaded. Cached associations are cleared.
         #
         # @example

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -31,7 +31,7 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          { association[:name] => klass.initialize_collection(klass, :data => data[data_key]) }
+          { association[:name] => klass.instantiate_collection(klass, :data => data[data_key]) }
         end
 
         # Initialize a new object with a foreign key to the parent
@@ -92,7 +92,7 @@ module Her
         # @private
         def assign_nested_attributes(attributes)
           data = attributes.is_a?(Hash) ? attributes.values : attributes
-          @parent.attributes[@name] = @klass.initialize_collection(@klass, :data => data)
+          @parent.attributes[@name] = @klass.instantiate_collection(@klass, :data => data)
         end
       end
     end

--- a/lib/her/model/associations/has_many_association.rb
+++ b/lib/her/model/associations/has_many_association.rb
@@ -31,7 +31,7 @@ module Her
           return {} unless data[data_key]
 
           klass = klass.her_nearby_class(association[:class_name])
-          { association[:name] => Her::Model::Attributes.initialize_collection(klass, :data => data[data_key]) }
+          { association[:name] => klass.initialize_collection(klass, :data => data[data_key]) }
         end
 
         # Initialize a new object with a foreign key to the parent
@@ -92,7 +92,7 @@ module Her
         # @private
         def assign_nested_attributes(attributes)
           data = attributes.is_a?(Hash) ? attributes.values : attributes
-          @parent.attributes[@name] = Her::Model::Attributes.initialize_collection(@klass, :data => data)
+          @parent.attributes[@name] = @klass.initialize_collection(@klass, :data => data)
         end
       end
     end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -16,7 +16,13 @@ module Her
       #     include Her::Model
       #   end
       #
-      #  User.new(name: "Tobias") # => #<User name="Tobias">
+      #  User.new(name: "Tobias")
+      #  # => #<User name="Tobias">
+      #
+      #  User.new do |u|
+      #    u.name = "Tobias"
+      #  end
+      #  # => #<User name="Tobias">
       def initialize(attributes={})
         attributes ||= {}
         @metadata = attributes.delete(:_metadata) || {}
@@ -25,7 +31,6 @@ module Her
 
         attributes = self.class.default_scope.apply_to(attributes)
         assign_attributes(attributes)
-
         yield self if block_given?
         run_callbacks :initialize
       end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -30,22 +30,6 @@ module Her
         run_callbacks :initialize
       end
 
-      # Initialize a collection of resources
-      #
-      # @private
-      def self.initialize_collection(klass, parsed_data={})
-        collection_data = klass.extract_array(parsed_data).map do |item_data|
-          if item_data.kind_of?(klass)
-            resource = item_data
-          else
-            resource = klass.new(klass.parse(item_data))
-            resource.run_callbacks :find
-          end
-          resource
-        end
-        Her::Collection.new(collection_data, parsed_data[:metadata], parsed_data[:errors])
-      end
-
       # Use setter methods of model for each key / value pair in params
       # Return key / value pairs for which no setter method was defined on the model
       #
@@ -177,12 +161,28 @@ module Her
       end
 
       module ClassMethods
+        # Initialize a collection of resources
+        #
+        # @private
+        def initialize_collection(klass, parsed_data={})
+          collection_data = klass.extract_array(parsed_data).map do |item_data|
+            if item_data.kind_of?(klass)
+              resource = item_data
+            else
+              resource = klass.new(klass.parse(item_data))
+              resource.run_callbacks :find
+            end
+            resource
+          end
+          Her::Collection.new(collection_data, parsed_data[:metadata], parsed_data[:errors])
+        end
+
         # Initialize a collection of resources with raw data from an HTTP request
         #
         # @param [Array] parsed_data
         # @private
         def new_collection(parsed_data)
-          Her::Model::Attributes.initialize_collection(self, parsed_data)
+          initialize_collection(self, parsed_data)
         end
 
         # Initialize a new object with the "raw" parsed_data from the parsing middleware

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -16,13 +16,13 @@ module Her
       #     include Her::Model
       #   end
       #
-      #  User.new(name: "Tobias")
-      #  # => #<User name="Tobias">
+      #   User.new(name: "Tobias")
+      #   # => #<User name="Tobias">
       #
-      #  User.new do |u|
-      #    u.name = "Tobias"
-      #  end
-      #  # => #<User name="Tobias">
+      #   User.new do |u|
+      #     u.name = "Tobias"
+      #   end
+      #   # => #<User name="Tobias">
       def initialize(attributes={})
         attributes ||= {}
         @metadata = attributes.delete(:_metadata) || {}
@@ -105,7 +105,8 @@ module Her
         @attributes[self.class.primary_key]
       end
 
-      # Return `true` if the other object is also a Her::Model and has matching data
+      # Return `true` if the other object is also a Her::Model and has matching
+      # data
       #
       # @private
       def ==(other)
@@ -185,7 +186,8 @@ module Her
         end
 
         # Use setter methods of model for each key / value pair in params
-        # Return key / value pairs for which no setter method was defined on the model
+        # Return key / value pairs for which no setter method was defined on the
+        # model
         #
         # @private
         def use_setter_methods(model, params = {})
@@ -203,7 +205,8 @@ module Her
           end
         end
 
-        # Define attribute method matchers to automatically define them using ActiveModel's define_attribute_methods.
+        # Define attribute method matchers to automatically define them using
+        # ActiveModel's define_attribute_methods.
         #
         # @private
         def define_attribute_method_matchers
@@ -211,18 +214,22 @@ module Her
           attribute_method_suffix '?'
         end
 
-        # Create a mutex for dynamically generated attribute methods or use one defined by ActiveModel.
+        # Create a mutex for dynamically generated attribute methods or use one
+        # defined by ActiveModel.
         #
         # @private
         def attribute_methods_mutex
-          @attribute_methods_mutex ||= if generated_attribute_methods.respond_to? :mu_synchronize
-                                         generated_attribute_methods
-                                       else
-                                         Mutex.new
-                                       end
+          @attribute_methods_mutex ||= begin
+            if generated_attribute_methods.respond_to? :mu_synchronize
+              generated_attribute_methods
+            else
+              Mutex.new
+            end
+          end
         end
 
-        # Define the attributes that will be used to track dirty attributes and validations
+        # Define the attributes that will be used to track dirty attributes and
+        # validations
         #
         # @param [Array] attributes
         # @example
@@ -236,7 +243,8 @@ module Her
           end
         end
 
-        # Define the accessor in which the API response errors (obtained from the parsing middleware) will be stored
+        # Define the accessor in which the API response errors (obtained from
+        # the parsing middleware) will be stored
         #
         # @param [Symbol] store_response_errors
         #
@@ -249,7 +257,8 @@ module Her
           store_her_data(:response_errors, value)
         end
 
-        # Define the accessor in which the API response metadata (obtained from the parsing middleware) will be stored
+        # Define the accessor in which the API response metadata (obtained from
+        # the parsing middleware) will be stored
         #
         # @param [Symbol] store_metadata
         #
@@ -264,9 +273,10 @@ module Her
 
         # @private
         def setter_method_names
-          @_her_setter_method_names ||= instance_methods.inject(Set.new) do |memo, method_name|
-            memo << method_name.to_s if method_name.to_s.end_with?('=')
-            memo
+          @_her_setter_method_names ||= begin
+            instance_methods.each_with_object(Set.new) do |method, memo|
+              memo << method.to_s if method.to_s.end_with?('=')
+            end
           end
         end
 

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -138,10 +138,11 @@ module Her
       end
 
       module ClassMethods
+
         # Initialize a collection of resources
         #
         # @private
-        def initialize_collection(klass, parsed_data={})
+        def instantiate_collection(klass, parsed_data={})
           collection_data = klass.extract_array(parsed_data).map do |item_data|
             if item_data.kind_of?(klass)
               resource = item_data
@@ -159,7 +160,7 @@ module Her
         # @param [Array] parsed_data
         # @private
         def new_collection(parsed_data)
-          initialize_collection(self, parsed_data)
+          instantiate_collection(self, parsed_data)
         end
 
         # Initialize a new object with the "raw" parsed_data from the parsing middleware

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -188,22 +188,18 @@ module Her
         # Return key / value pairs for which no setter method was defined on the model
         #
         # @private
-        def use_setter_methods(model, params)
-          params ||= {}
-
-          reserved_keys = [:id, model.class.primary_key] + model.class.association_keys
-          model.class.attributes *params.keys.reject { |k| reserved_keys.include?(k) || reserved_keys.map(&:to_s).include?(k) }
+        def use_setter_methods(model, params = {})
+          reserved = [:id, model.class.primary_key, *model.class.association_keys]
+          model.class.attributes *params.keys.reject { |k| reserved.include?(k) }
 
           setter_method_names = model.class.setter_method_names
-          params.inject({}) do |memo, (key, value)|
+          params.each_with_object({}) do |(key, value), memo|
             setter_method = key.to_s + '='
             if setter_method_names.include?(setter_method)
               model.send(setter_method, value)
             else
-              key = key.to_sym if key.is_a?(String)
-              memo[key] = value
+              memo[key.to_sym] = value
             end
-            memo
           end
         end
 

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -89,7 +89,7 @@ module Her
 
       # @private
       def respond_to_missing?(method, include_private = false)
-        method.to_s.end_with?('=') || method.to_s.end_with?('?') || @attributes.include?(method) || super
+        method.to_s =~ /[?=]$/ || @attributes.include?(method) || super
       end
 
       # Assign new attributes to a resource

--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -71,7 +71,7 @@ module Her
                 if parsed_data[:data].is_a?(Array) || active_model_serializers_format? || json_api_format?
                   new_collection(parsed_data)
                 else
-                  new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
+                  new_from_parsed_data(parsed_data)
                 end
               end
             end
@@ -91,7 +91,7 @@ module Her
             def #{method}_resource(path, params={})
               path = build_request_path_from_string_or_symbol(path, params)
               send(:"#{method}_raw", path, params) do |parsed_data, response|
-                new(parse(parsed_data[:data]).merge :_metadata => parsed_data[:metadata], :_errors => parsed_data[:errors])
+                new_from_parsed_data(parsed_data)
               end
             end
 


### PR DESCRIPTION
`attributes.rb` needs a little routine maintenance and tlc 💅 💅 

- reuse regular expression for predicate and writer methods in `respond_to_missing`
- move `initialize_collection` and `use_setter_methods` to ClassMethods section with other class methods
- rename `initialize_collection` to `instantiate_collection` and add an `instantiate_record` method similar to [ActiveResource](https://github.com/rails/activeresource/blob/c38f18ce4ee6c83e034e7b465459fdd547804b64/lib/active_resource/base.rb#L1061).
- replace duplication of `new_from_parsed_data` and `instantiate_record` from `http` and other files
- apply 80 character limit for readability