### PR TITLE
correct order of create, update, and save callbacks

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -39,8 +39,8 @@ module Her
         callback = new? ? :create : :update
         method = self.class.method_for(callback)
 
-        run_callbacks callback do
-          run_callbacks :save do
+        run_callbacks :save do
+          run_callbacks callback do
             params = to_params
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               assign_attributes(self.class.parse(parsed_data[:data])) if parsed_data[:data].any?


### PR DESCRIPTION
Save callbacks are slightly off. `create/update` are being executed before `save`. The [correct order](http://guides.rubyonrails.org/active_record_callbacks.html#creating-an-object) is

- before_save
- before_create/before_update
- after_create/after_update
- after_save