### PR TITLE
allow model to have attribute that is the same as its name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /pkg
 /tmp
 /coverage
+.bundle
+/vendor

--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,4 @@
+Pry.commands.alias_command 'c', 'continue'
+Pry.commands.alias_command 's', 'step'
+Pry.commands.alias_command 'n', 'next'
+Pry.commands.alias_command 'f', 'finish'

--- a/her.gemspec
+++ b/her.gemspec
@@ -20,6 +20,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "json", "~> 1.8"
+  s.add_development_dependency "pry",                       "~> 0.10"
+  s.add_development_dependency "pry-byebug",                "~> 3.4"
+  s.add_development_dependency "pry-remote",                "~> 0.1"
+  s.add_development_dependency "pry-stack_explorer",        "~> 0.4"
 
   s.add_runtime_dependency "activemodel", ">= 3.0.0", "<= 6.0.0"
   s.add_runtime_dependency "activesupport", ">= 3.0.0", "<= 6.0.0"

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -135,7 +135,8 @@ module Her
 
         # @private
         def root_element_included?(data)
-          data.keys.to_s.include? @_her_root_element.to_s
+          data.keys.include?(root_element) &&
+            (data[root_element].is_a?(Hash) || data[root_element].is_a?(Array))
         end
 
         # @private


### PR DESCRIPTION
We have a model called `Rate` that has an attribute legacy `rate` which is causing issues when using this gem. This change checks the type of the key to make sure it should be parsed as an object or treated as an attribute.

I also added `pry` because it is useful for debugging. Let me know if you want me to remove it.