### PR TITLE
Add support for the OPTIONS verb

### DIFF
--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -89,19 +89,26 @@ module Her
       path = opts.delete(:_path)
       headers = opts.delete(:_headers)
       opts.delete_if { |key, value| key.to_s =~ /^_/ } # Remove all internal parameters
-      response = @connection.send method do |request|
+      # Faraday doesn't support the OPTIONS verb because of a name collision with an internal options method
+      # so we need to call run_request directly.
+      if method == :options
         request.headers.merge!(headers) if headers
-        if method == :get
-          # For GET requests, treat additional parameters as querystring data
-          request.url path, opts
-        else
-          # For POST, PUT and DELETE requests, treat additional parameters as request body
-          request.url path
-          request.body = opts
+        response = @connection.run_request method, path, opts, headers
+      else
+        response = @connection.send method do |request|
+          request.headers.merge!(headers) if headers
+          if method == :get
+            # For GET requests, treat additional parameters as querystring data
+            request.url path, opts
+          else
+            # For POST, PUT and DELETE requests, treat additional parameters as request body
+            request.url path
+            request.body = opts
+          end
         end
       end
-
       { :parsed_data => response.env[:body], :response => response }
+
     end
 
     private

--- a/lib/her/api.rb
+++ b/lib/her/api.rb
@@ -89,9 +89,9 @@ module Her
       path = opts.delete(:_path)
       headers = opts.delete(:_headers)
       opts.delete_if { |key, value| key.to_s =~ /^_/ } # Remove all internal parameters
-      # Faraday doesn't support the OPTIONS verb because of a name collision with an internal options method
-      # so we need to call run_request directly.
       if method == :options
+        # Faraday doesn't support the OPTIONS verb because of a name collision with an internal options method
+        # so we need to call run_request directly.
         request.headers.merge!(headers) if headers
         response = @connection.run_request method, path, opts, headers
       else

--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -3,7 +3,7 @@ module Her
     # This module interacts with Her::API to fetch HTTP data
     module HTTP
       extend ActiveSupport::Concern
-      METHODS = [:get, :post, :put, :patch, :delete]
+      METHODS = [:get, :post, :put, :patch, :delete, :options]
 
       # For each HTTP method, define these class methods:
       #

--- a/lib/her/version.rb
+++ b/lib/her/version.rb
@@ -1,3 +1,3 @@
 module Her
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION

Add support for the OPTIONS verb, which requires us to use Faraday's run_request() method instead of the dynamically-generated method associated with the verb name (Faraday.options is a different thing - see lostisland/faraday#305)

@zacharywelch are you ok for me to merge into master and push a 0.9.1 gem (need it for a project we're working on)?