### PR TITLE
Update the setter methods cache after defining new attributes

### DIFF
--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -239,7 +239,11 @@ module Her
         #   end
         def attributes(*attributes)
           attribute_methods_mutex.synchronize do
-            define_attribute_methods attributes
+            old_methods = generated_attribute_methods.instance_methods
+            define_attribute_methods(attributes).tap do
+              new_methods = generated_attribute_methods.instance_methods
+              @_her_setter_method_names = nil if old_methods != new_methods
+            end
           end
         end
 

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -393,4 +393,21 @@ describe Her::Model::Attributes do
       end
     end
   end
+
+  it 'updates the cache of setter methods' do
+    spawn_model "Foo::User" do
+      attr_reader :setter_called
+    end
+
+    Foo::User.new(fullname: "Tobias Fünke")
+
+    Foo::User.class_eval do
+      def password=(value)
+        @setter_called = true
+      end
+    end
+
+    user = Foo::User.new(password: 'supersecret')
+    expect(user.setter_called).to be_truthy
+  end
 end


### PR DESCRIPTION
Not doing so resulted in very strange behaviour. Any previously unseen attributes passed to `new` with `send_only_modified_attributes` enabled would be missing from the request parameters. This is because change tracking is only effective for setter methods.

Now this is fixed, it is unclear to me what the `@attributes.merge!` line in `assign_attributes` is for. In theory, all the given attributes (that are not associations) should have setter methods defined by this point. It should probably still trigger change tracking in any case.