### PR TITLE
Serialize ActiveModel instances that do not use Her

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -41,6 +41,17 @@ module Her
             end
           end
 
+          # Faraday does not serialize everything thrown at it and
+          # some parameters may still be complex objects by this point
+          # so attempt to serialize further where possible. This is
+          # useful for classes that use ActiveModel but not Her.
+          filtered_attributes.each do |key, value|
+            case value
+            when ActiveModel::Serialization
+              filtered_attributes[key] = value.serializable_hash
+            end
+          end
+
           if include_root_in_json?
             if json_api_format?
               { included_root_element => [filtered_attributes] }

--- a/spec/model/parse_spec.rb
+++ b/spec/model/parse_spec.rb
@@ -342,4 +342,30 @@ describe Her::Model::Parse do
       expect(user.to_params).to eql(user: { first_name: "Someone" })
     end
   end
+
+  context 'when passed a non-Her ActiveModel instance' do
+    before do
+      klass = Class.new do
+        include ActiveModel::Serialization
+
+        def attributes
+          { name: nil }
+        end
+
+        def name
+          'foo'
+        end
+      end
+
+      @model = klass.new
+
+      Her::API.setup
+      spawn_model 'Foo::User'
+    end
+
+    it 'serializes the instance in `to_params`' do
+      attributes = { model: @model }
+      expect(Foo::User.to_params(attributes)).to eq(model: { name: 'foo' })
+    end
+  end
 end


### PR DESCRIPTION
Faraday does not serialize everything thrown at it and passing such instances currently just results in useless ugly strings.

`ActiveModel::Serialization` needs to be included for this to work.