### PR TITLE
Raise an error when a class cannot be found

### DIFF
--- a/lib/her/model/introspection.rb
+++ b/lib/her/model/introspection.rb
@@ -38,7 +38,7 @@ module Her
         #
         # @private
         def her_nearby_class(name)
-          her_sibling_class(name) || name.constantize rescue nil
+          her_sibling_class(name) || name.constantize
         end
 
         protected

--- a/spec/model/introspection_spec.rb
+++ b/spec/model/introspection_spec.rb
@@ -73,7 +73,7 @@ describe Her::Model::Introspection do
         expect(Foo::User.her_nearby_class("AccessRecord")).to eq(Foo::AccessRecord)
         expect(AccessRecord.her_nearby_class("Log")).to eq(Log)
         expect(Foo::User.her_nearby_class("Log")).to eq(Log)
-        expect(Foo::User.her_nearby_class("X")).to be_nil
+        expect{Foo::User.her_nearby_class("X")}.to raise_error(NameError)
       end
     end
   end


### PR DESCRIPTION
Fixes issue #474.

Her now will raise an error rather than ignoring the class_name parameter if the class cannot be loaded.