### PR TITLE
 Prevent 'scope' from defining scope methods on the wrong Her models

### DIFF
--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -174,10 +174,8 @@ module Her
             instance_exec(*args, &code)
           end
 
-          # Add the scope method to the Relation class
-          Relation.instance_eval do
-            define_method(name) { |*args| instance_exec(*args, &code) }
-          end
+          # Add the scope method to the blank_relation
+          blank_relation.define_singleton_method(name) { |*args| instance_exec(*args, &code) }
         end
 
         # @private

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -267,9 +267,9 @@ module Her
           resource
         end
 
-        private
         # @private
         def blank_relation
+          @blank_relation ||= superclass.blank_relation.clone.tap { |r| r.parent = self } if superclass.respond_to?(:blank_relation)
           @blank_relation ||= Relation.new(self)
         end
       end

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -175,7 +175,7 @@ module Her
           end
 
           # Add the scope method to the blank_relation
-          blank_relation.define_singleton_method(name) { |*args| instance_exec(*args, &code) }
+          scoped.define_singleton_method(name) { |*args| instance_exec(*args, &code) }
         end
 
         # @private

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -174,7 +174,7 @@ module Her
             instance_exec(*args, &code)
           end
 
-          # Add the scope method to the blank_relation
+          # Add the scope method to the default/blank relation
           scoped.define_singleton_method(name) { |*args| instance_exec(*args, &code) }
         end
 

--- a/lib/her/model/relation.rb
+++ b/lib/her/model/relation.rb
@@ -3,6 +3,7 @@ module Her
     class Relation
       # @private
       attr_accessor :params
+      attr_writer :parent
 
       # @private
       def initialize(parent)

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -305,43 +305,45 @@ describe Her::Model::ORM do
     end
   end
 
-  describe :scope do
-    before do
-      spawn_model "Foo::User" do
-        scope :baz, ->(yar) { where(baz: yar) }
-      end
-      spawn_model "Bar::User"
-    end
-
-    it 'does not pollute a shared namespace' do
-      expect(Foo::User.public_methods).to include(:baz)
-      expect(Foo::User.scoped.public_methods).to include(:baz)
-      expect(Foo::User.where(foo: '123').public_methods).to include(:baz)
-      expect(Bar::User.public_methods).not_to include(:baz)
-      expect(Bar::User.scoped.public_methods).not_to include(:baz)
-      expect(Bar::User.where(foo: '123').public_methods).not_to include(:baz)
-      expect(Her::Model::Relation.public_instance_methods).not_to include(:baz)
-    end
-  end
-
-  describe :default_scope do
-    before do
-      spawn_model 'Foo::User' do
-        default_scope -> { where(foo: 123) }
-        scope :bar, -> { where(bar: true ) }
+  context 'defining scopes' do
+    context 'when defining a single scope' do
+      before do
+        spawn_model "Foo::User" do
+          scope :baz, ->(yar) { where(baz: yar) }
+        end
+        spawn_model "Bar::User"
       end
 
-      spawn_model 'Bar::User' do
-        scope :foo, -> { where(foo: true ) }
-        default_scope -> { where(bar: 123) }
+      it 'does not pollute a shared namespace' do
+        expect(Foo::User.public_methods).to include(:baz)
+        expect(Foo::User.scoped.public_methods).to include(:baz)
+        expect(Foo::User.where(foo: '123').public_methods).to include(:baz)
+        expect(Bar::User.public_methods).not_to include(:baz)
+        expect(Bar::User.scoped.public_methods).not_to include(:baz)
+        expect(Bar::User.where(foo: '123').public_methods).not_to include(:baz)
+        expect(Her::Model::Relation.public_instance_methods).not_to include(:baz)
       end
     end
 
-    it 'preserves scope definitions regardless of call order' do
-      expect(Foo::User.public_methods).to include(:bar)
-      expect(Foo::User.scoped.public_methods).to include(:bar)
-      expect(Bar::User.public_methods).to include(:foo)
-      expect(Bar::User.scoped.public_methods).to include(:foo)
+    context 'when defining scopes alongside a default_scope' do
+      before do
+        spawn_model 'Foo::User' do
+          default_scope -> { where(foo: 123) }
+          scope :bar, -> { where(bar: true ) }
+        end
+
+        spawn_model 'Bar::User' do
+          scope :foo, -> { where(foo: true ) }
+          default_scope -> { where(bar: 123) }
+        end
+      end
+
+      it 'preserves scope definitions regardless of call order' do
+        expect(Foo::User.public_methods).to include(:bar)
+        expect(Foo::User.scoped.public_methods).to include(:bar)
+        expect(Bar::User.public_methods).to include(:foo)
+        expect(Bar::User.scoped.public_methods).to include(:foo)
+      end
     end
   end
 

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -305,6 +305,21 @@ describe Her::Model::ORM do
     end
   end
 
+  describe :scope do
+    before do
+      spawn_model "Foo::User" do
+        collection_path '/organizations/:org_id/users'
+        scope :created_on, ->(date) { where(created_on: date) }
+        scope :for_org_id, ->(org_id) { where(_org_id: org_id) }
+      end
+    end
+
+    it 'does not pollute the global namespace' do
+      expect(Her::Model::Relation.public_instance_methods).to_not include(:created_on, :for_org_id)
+      expect(Foo::User.scoped.public_methods).to include(:created_on, :for_org_id)
+    end
+  end
+
   context "building resources" do
     context "when request_new_object_on_build is not set (default)" do
       before do

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -305,48 +305,6 @@ describe Her::Model::ORM do
     end
   end
 
-  context 'defining scopes' do
-    context 'when defining a single scope' do
-      before do
-        spawn_model "Foo::User" do
-          scope :baz, ->(yar) { where(baz: yar) }
-        end
-        spawn_model "Bar::User"
-      end
-
-      it 'does not pollute a shared namespace' do
-        expect(Foo::User.public_methods).to include(:baz)
-        expect(Foo::User.scoped.public_methods).to include(:baz)
-        expect(Foo::User.where(foo: '123').public_methods).to include(:baz)
-        expect(Bar::User.public_methods).not_to include(:baz)
-        expect(Bar::User.scoped.public_methods).not_to include(:baz)
-        expect(Bar::User.where(foo: '123').public_methods).not_to include(:baz)
-        expect(Her::Model::Relation.public_instance_methods).not_to include(:baz)
-      end
-    end
-
-    context 'when defining scopes alongside a default_scope' do
-      before do
-        spawn_model 'Foo::User' do
-          default_scope -> { where(foo: 123) }
-          scope :bar, -> { where(bar: true ) }
-        end
-
-        spawn_model 'Bar::User' do
-          scope :foo, -> { where(foo: true ) }
-          default_scope -> { where(bar: 123) }
-        end
-      end
-
-      it 'preserves scope definitions regardless of call order' do
-        expect(Foo::User.public_methods).to include(:bar)
-        expect(Foo::User.scoped.public_methods).to include(:bar)
-        expect(Bar::User.public_methods).to include(:foo)
-        expect(Bar::User.scoped.public_methods).to include(:foo)
-      end
-    end
-  end
-
   context "building resources" do
     context "when request_new_object_on_build is not set (default)" do
       before do

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -308,15 +308,17 @@ describe Her::Model::ORM do
   describe :scope do
     before do
       spawn_model "Foo::User" do
-        collection_path '/organizations/:org_id/users'
-        scope :created_on, ->(date) { where(created_on: date) }
-        scope :for_org_id, ->(org_id) { where(_org_id: org_id) }
+        scope :baz, ->(yar) { where(baz: yar) }
       end
+      spawn_model "Bar::User"
     end
 
-    it 'does not pollute the global namespace' do
-      expect(Her::Model::Relation.public_instance_methods).to_not include(:created_on, :for_org_id)
-      expect(Foo::User.scoped.public_methods).to include(:created_on, :for_org_id)
+    it 'does not pollute a shared namespace' do
+      expect(Foo::User.public_methods).to include(:baz)
+      expect(Foo::User.scoped.public_methods).to include(:baz)
+      expect(Bar::User.public_methods).not_to include(:baz)
+      expect(Bar::User.scoped.public_methods).not_to include(:baz)
+      expect(Her::Model::Relation.public_instance_methods).not_to include(:baz)
     end
   end
 

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -324,6 +324,27 @@ describe Her::Model::ORM do
     end
   end
 
+  describe :default_scope do
+    before do
+      spawn_model 'Foo::User' do
+        default_scope -> { where(foo: 123) }
+        scope :bar, -> { where(bar: true ) }
+      end
+
+      spawn_model 'Bar::User' do
+        scope :foo, -> { where(foo: true ) }
+        default_scope -> { where(bar: 123) }
+      end
+    end
+
+    it 'preserves scope definitions regardless of call order' do
+      expect(Foo::User.public_methods).to include(:bar)
+      expect(Foo::User.scoped.public_methods).to include(:bar)
+      expect(Bar::User.public_methods).to include(:foo)
+      expect(Bar::User.scoped.public_methods).to include(:foo)
+    end
+  end
+
   context "building resources" do
     context "when request_new_object_on_build is not set (default)" do
       before do

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -316,8 +316,10 @@ describe Her::Model::ORM do
     it 'does not pollute a shared namespace' do
       expect(Foo::User.public_methods).to include(:baz)
       expect(Foo::User.scoped.public_methods).to include(:baz)
+      expect(Foo::User.where(foo: '123').public_methods).to include(:baz)
       expect(Bar::User.public_methods).not_to include(:baz)
       expect(Bar::User.scoped.public_methods).not_to include(:baz)
+      expect(Bar::User.where(foo: '123').public_methods).not_to include(:baz)
       expect(Her::Model::Relation.public_instance_methods).not_to include(:baz)
     end
   end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -79,8 +79,8 @@ describe Her::Model::Relation do
       end
 
       it "propagates the scopes through its children" do
-        @users = User.page(2)
-        expect(@users.length).to eq(2)
+        expect(User.page(2).length).to eq(2)
+        expect(User.scoped.page(2).length).to eq(2)
       end
     end
   end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -186,7 +186,9 @@ describe Her::Model::Relation do
         end
       end
 
-      it 'does not cause the models to share a method definition' do
+      it 'does not cause the models to share a scope definition' do
+        expect(Foo::User.scoped.foo.params[:foo]).to eq true
+        expect(Bar::User.scoped.foo.params[:foo]).to eq false
         expect(Foo::User.scoped.method(:foo).unbind).not_to eq(Bar::User.scoped.method(:foo).unbind)
       end
     end

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -170,6 +170,21 @@ describe Her::Model::Relation do
       expect(Bar::User.where(foo: '123').public_methods).not_to include(:foo, :bar, :baz)
       expect(Her::Model::Relation.public_instance_methods).not_to include(:foo, :bar, :baz)
     end
+
+    context 'when two scopes have the same name' do
+      before do
+        spawn_model "Foo::User" do
+          scope :foo, -> { where(foo: true) }
+        end
+        spawn_model 'Bar::User' do
+          scope :foo, -> { where(foo: false) }
+        end
+      end
+
+      it 'does not cause the models to share a method definition' do
+        expect(Foo::User.scoped.method(:foo).unbind).not_to eq(Bar::User.scoped.method(:foo).unbind)
+      end
+    end
   end
 
   describe :default_scope do

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -143,7 +143,6 @@ describe Her::Model::Relation do
         scope :bar, ->(v) { where(where: v) }
         scope :baz, -> { bar(6) }
       end
-      spawn_model 'Bar::User'
     end
 
     it "passes query parameters" do
@@ -161,14 +160,20 @@ describe Her::Model::Relation do
       expect(@user.id).to eq(4)
     end
 
-    it 'does not pollute a shared namespace' do
-      expect(Foo::User.public_methods).to include(:foo, :bar, :baz)
-      expect(Foo::User.scoped.public_methods).to include(:foo, :bar, :baz)
-      expect(Foo::User.where(foo: '123').public_methods).to include(:foo, :bar, :baz)
-      expect(Bar::User.public_methods).not_to include(:foo, :bar, :baz)
-      expect(Bar::User.scoped.public_methods).not_to include(:foo, :bar, :baz)
-      expect(Bar::User.where(foo: '123').public_methods).not_to include(:foo, :bar, :baz)
-      expect(Her::Model::Relation.public_instance_methods).not_to include(:foo, :bar, :baz)
+    context 'when there is another model present' do
+      before do
+        spawn_model 'Bar::User'
+      end
+
+      it 'does not pollute a shared namespace' do
+        expect(Foo::User.public_methods).to include(:foo, :bar, :baz)
+        expect(Foo::User.scoped.public_methods).to include(:foo, :bar, :baz)
+        expect(Foo::User.where(foo: '123').public_methods).to include(:foo, :bar, :baz)
+        expect(Bar::User.public_methods).not_to include(:foo, :bar, :baz)
+        expect(Bar::User.scoped.public_methods).not_to include(:foo, :bar, :baz)
+        expect(Bar::User.where(foo: '123').public_methods).not_to include(:foo, :bar, :baz)
+        expect(Her::Model::Relation.public_instance_methods).not_to include(:foo, :bar, :baz)
+      end
     end
 
     context 'when two scopes have the same name' do


### PR DESCRIPTION
I've added tests to cover the cases I've encountered. Before my fix, you would see these new examples fail, because scope methods were being defined globally on `Her::Model::Relation`. (I also added one passing default_scope spec to test for an issue that I wanted to avoid introducing.)

To demonstrate the issue, take these two Her models:

```ruby
class B::User
  include Her::Model

  scope :foo, -> { where(bar: true) }
end

class A::User
  include Her::Model

  scope :foo, -> { where(bar: false) }
end
```

#### Before this fix:

```ruby
A::User.scoped.foo.params[:bar]
#=> false
B::User.scoped.foo.params[:bar]
#=> false -- OHNO!
```

Whoops! We can check, and the scope method definitions are actually the same:

```ruby
A::User.scoped.method(:foo).unbind ==  B::User.scoped.method(:foo).unbind
# => true
```

Note that the `scoped` is necessary here. It only affects _chained_ scoped, not scopes called directly on the class:

```ruby
A::User.foo.params[:bar]
#=> false
B::User.foo.params[:bar]
#=> true
A::User.method(:foo).unbind ==  B::User.method(:foo).unbind
# => false
```

#### After this fix:

```ruby
A::User.scoped.foo.params[:bar]
#=> false
B::User.scoped.foo.params[:bar]
#=> true
A::User.scoped.method(:foo).unbind ==  B::User.scoped.method(:foo).unbind
# => false
```

🎉 