### PR TITLE
Refactor associations_spec

### DIFF
--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -8,10 +8,21 @@ describe Her::Model::Associations do
 
     context "single has_many association" do
       before { Foo::User.has_many :comments }
+      subject { super()[:has_many] }
 
       describe "[:has_many]" do
-        subject { super()[:has_many] }
-        it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }] }
+        let(:association) do
+          {
+            name: :comments,
+            data_key: :comments,
+            default: [],
+            class_name: "Comment",
+            path: "/comments",
+            inverse_of: nil
+          }
+        end
+
+        it { is_expected.to eql [association] }
       end
     end
 
@@ -20,19 +31,50 @@ describe Her::Model::Associations do
         Foo::User.has_many :comments
         Foo::User.has_many :posts
       end
+      subject { super()[:has_many] }
 
       describe "[:has_many]" do
-        subject { super()[:has_many] }
-        it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Comment", path: "/comments", inverse_of: nil }, { name: :posts, data_key: :posts, default: [], class_name: "Post", path: "/posts", inverse_of: nil }] }
+        let(:comments_association) do
+          {
+            name: :comments,
+            data_key: :comments,
+            default: [],
+            class_name: "Comment",
+            path: "/comments",
+            inverse_of: nil
+          }
+        end
+        let(:posts_association) do
+          {
+            name: :posts,
+            data_key: :posts,
+            default: [],
+            class_name: "Post",
+            path: "/posts",
+            inverse_of: nil
+          }
+        end
+
+        it { is_expected.to eql [comments_association, posts_association] }
       end
     end
 
     context "single has_one association" do
       before { Foo::User.has_one :category }
+      subject { super()[:has_one] }
 
       describe "[:has_one]" do
-        subject { super()[:has_one] }
-        it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }] }
+        let(:association) do
+          {
+            name: :category,
+            data_key: :category,
+            default: nil,
+            class_name: "Category",
+            path: "/category"
+          }
+        end
+
+        it { is_expected.to eql [association] }
       end
     end
 
@@ -41,19 +83,49 @@ describe Her::Model::Associations do
         Foo::User.has_one :category
         Foo::User.has_one :role
       end
+      subject { super()[:has_one] }
 
       describe "[:has_one]" do
-        subject { super()[:has_one] }
-        it { is_expected.to eql [{ name: :category, data_key: :category, default: nil, class_name: "Category", path: "/category" }, { name: :role, data_key: :role, default: nil, class_name: "Role", path: "/role" }] }
+        let(:category_association) do
+          {
+            name: :category,
+            data_key: :category,
+            default: nil,
+            class_name: "Category",
+            path: "/category"
+          }
+        end
+        let(:role_association) do
+          {
+            name: :role,
+            data_key: :role,
+            default: nil,
+            class_name: "Role",
+            path: "/role"
+          }
+        end
+
+        it { is_expected.to eql [category_association, role_association] }
       end
     end
 
     context "single belongs_to association" do
       before { Foo::User.belongs_to :organization }
+      subject { super()[:belongs_to] }
 
       describe "[:belongs_to]" do
-        subject { super()[:belongs_to] }
-        it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }] }
+        let(:association) do
+          {
+            name: :organization,
+            data_key: :organization,
+            default: nil,
+            class_name: "Organization",
+            foreign_key: "organization_id",
+            path: "/organizations/:id"
+          }
+        end
+
+        it { is_expected.to eql [association] }
       end
     end
 
@@ -62,10 +134,31 @@ describe Her::Model::Associations do
         Foo::User.belongs_to :organization
         Foo::User.belongs_to :family
       end
+      subject { super()[:belongs_to] }
 
       describe "[:belongs_to]" do
-        subject { super()[:belongs_to] }
-        it { is_expected.to eql [{ name: :organization, data_key: :organization, default: nil, class_name: "Organization", foreign_key: "organization_id", path: "/organizations/:id" }, { name: :family, data_key: :family, default: nil, class_name: "Family", foreign_key: "family_id", path: "/families/:id" }] }
+        let(:organization_association) do
+          {
+            name: :organization,
+            data_key: :organization,
+            default: nil,
+            class_name: "Organization",
+            foreign_key: "organization_id",
+            path: "/organizations/:id"
+          }
+        end
+        let(:family_association) do
+          {
+            name: :family,
+            data_key: :family,
+            default: nil,
+            class_name: "Family",
+            foreign_key: "family_id",
+            path: "/families/:id"
+          }
+        end
+
+        it { is_expected.to eql [organization_association, family_association] }
       end
     end
   end
@@ -76,29 +169,76 @@ describe Her::Model::Associations do
 
     context "in base class" do
       context "single has_many association" do
-        before { Foo::User.has_many :comments, class_name: "Post", inverse_of: :admin, data_key: :user_comments, default: {} }
+        before do
+          Foo::User.has_many :comments, class_name: "Post",
+                                        inverse_of: :admin,
+                                        data_key: :user_comments,
+                                        default: {}
+        end
+        subject { super()[:has_many] }
 
         describe "[:has_many]" do
-          subject { super()[:has_many] }
-          it { is_expected.to eql [{ name: :comments, data_key: :user_comments, default: {}, class_name: "Post", path: "/comments", inverse_of: :admin }] }
+          let(:association) do
+            {
+              name: :comments,
+              data_key: :user_comments,
+              default: {},
+              class_name: "Post",
+              path: "/comments",
+              inverse_of: :admin
+            }
+          end
+
+          it { is_expected.to eql [association] }
         end
       end
 
       context "single has_one association" do
-        before { Foo::User.has_one :category, class_name: "Topic", foreign_key: "topic_id", data_key: :topic, default: nil }
+        before do
+          Foo::User.has_one :category, class_name: "Topic",
+                                       foreign_key: "topic_id",
+                                       data_key: :topic, default: nil
+        end
+        subject { super()[:has_one] }
 
         describe "[:has_one]" do
-          subject { super()[:has_one] }
-          it { is_expected.to eql [{ name: :category, data_key: :topic, default: nil, class_name: "Topic", foreign_key: "topic_id", path: "/category" }] }
+          let(:association) do
+            {
+              name: :category,
+              data_key: :topic,
+              default: nil,
+              class_name: "Topic",
+              foreign_key: "topic_id",
+              path: "/category"
+            }
+          end
+
+          it { is_expected.to eql [association] }
         end
       end
 
       context "single belongs_to association" do
-        before { Foo::User.belongs_to :organization, class_name: "Business", foreign_key: "org_id", data_key: :org, default: true }
+        before do
+          Foo::User.belongs_to :organization, class_name: "Business",
+                                              foreign_key: "org_id",
+                                              data_key: :org,
+                                              default: true
+        end
+        subject { super()[:belongs_to] }
 
         describe "[:belongs_to]" do
-          subject { super()[:belongs_to] }
-          it { is_expected.to eql [{ name: :organization, data_key: :org, default: true, class_name: "Business", foreign_key: "org_id", path: "/organizations/:id" }] }
+          let(:association) do
+            {
+              name: :organization,
+              data_key: :org,
+              default: true,
+              class_name: "Business",
+              foreign_key: "org_id",
+              path: "/organizations/:id"
+            }
+          end
+
+          it { is_expected.to eql [association] }
         end
       end
     end
@@ -116,7 +256,18 @@ describe Her::Model::Associations do
 
         describe "[:has_many]" do
           subject { super()[:has_many] }
-          it { is_expected.to eql [{ name: :comments, data_key: :comments, default: [], class_name: "Post", path: "/comments", inverse_of: nil }] }
+          let(:association) do
+            {
+              name: :comments,
+              data_key: :comments,
+              default: [],
+              class_name: "Post",
+              path: "/comments",
+              inverse_of: nil
+            }
+          end
+
+          it { is_expected.to eql [association] }
         end
       end
     end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -4,14 +4,13 @@ require File.join(File.dirname(__FILE__), "../spec_helper.rb")
 describe Her::Model::Associations do
   context "setting associations without details" do
     before { spawn_model "Foo::User" }
-    subject { Foo::User.associations }
+    subject(:associations) { Foo::User.associations }
 
-    context "single has_many association" do
-      before { Foo::User.has_many :comments }
-      subject { super()[:has_many] }
+    describe "has_many associations" do
+      subject { associations[:has_many] }
 
-      describe "[:has_many]" do
-        let(:association) do
+      context "single" do
+        let(:comments_association) do
           {
             name: :comments,
             data_key: :comments,
@@ -21,19 +20,12 @@ describe Her::Model::Associations do
             inverse_of: nil
           }
         end
+        before { Foo::User.has_many :comments }
 
-        it { is_expected.to eql [association] }
+        it { is_expected.to eql [comments_association] }
       end
-    end
 
-    context "multiple has_many associations" do
-      before do
-        Foo::User.has_many :comments
-        Foo::User.has_many :posts
-      end
-      subject { super()[:has_many] }
-
-      describe "[:has_many]" do
+      context "multiple" do
         let(:comments_association) do
           {
             name: :comments,
@@ -54,17 +46,20 @@ describe Her::Model::Associations do
             inverse_of: nil
           }
         end
+        before do
+          Foo::User.has_many :comments
+          Foo::User.has_many :posts
+        end
 
         it { is_expected.to eql [comments_association, posts_association] }
       end
     end
 
-    context "single has_one association" do
-      before { Foo::User.has_one :category }
-      subject { super()[:has_one] }
+    describe "has_one associations" do
+      subject { associations[:has_one] }
 
-      describe "[:has_one]" do
-        let(:association) do
+      context "single" do
+        let(:category_association) do
           {
             name: :category,
             data_key: :category,
@@ -73,19 +68,12 @@ describe Her::Model::Associations do
             path: "/category"
           }
         end
+        before { Foo::User.has_one :category }
 
-        it { is_expected.to eql [association] }
+        it { is_expected.to eql [category_association] }
       end
-    end
 
-    context "multiple has_one associations" do
-      before do
-        Foo::User.has_one :category
-        Foo::User.has_one :role
-      end
-      subject { super()[:has_one] }
-
-      describe "[:has_one]" do
+      context "multiple" do
         let(:category_association) do
           {
             name: :category,
@@ -104,17 +92,20 @@ describe Her::Model::Associations do
             path: "/role"
           }
         end
+        before do
+          Foo::User.has_one :category
+          Foo::User.has_one :role
+        end
 
         it { is_expected.to eql [category_association, role_association] }
       end
     end
 
-    context "single belongs_to association" do
-      before { Foo::User.belongs_to :organization }
-      subject { super()[:belongs_to] }
+    describe "belongs_to associations" do
+      subject { associations[:belongs_to] }
 
-      describe "[:belongs_to]" do
-        let(:association) do
+      context "single" do
+        let(:organization_association) do
           {
             name: :organization,
             data_key: :organization,
@@ -124,19 +115,12 @@ describe Her::Model::Associations do
             path: "/organizations/:id"
           }
         end
+        before { Foo::User.belongs_to :organization }
 
-        it { is_expected.to eql [association] }
+        it { is_expected.to eql [organization_association] }
       end
-    end
 
-    context "multiple belongs_to association" do
-      before do
-        Foo::User.belongs_to :organization
-        Foo::User.belongs_to :family
-      end
-      subject { super()[:belongs_to] }
-
-      describe "[:belongs_to]" do
+      context "multiple" do
         let(:organization_association) do
           {
             name: :organization,
@@ -157,6 +141,10 @@ describe Her::Model::Associations do
             path: "/families/:id"
           }
         end
+        before do
+          Foo::User.belongs_to :organization
+          Foo::User.belongs_to :family
+        end
 
         it { is_expected.to eql [organization_association, family_association] }
       end
@@ -165,20 +153,14 @@ describe Her::Model::Associations do
 
   context "setting associations with details" do
     before { spawn_model "Foo::User" }
-    subject { Foo::User.associations }
+    subject(:associations) { Foo::User.associations }
 
     context "in base class" do
-      context "single has_many association" do
-        before do
-          Foo::User.has_many :comments, class_name: "Post",
-                                        inverse_of: :admin,
-                                        data_key: :user_comments,
-                                        default: {}
-        end
-        subject { super()[:has_many] }
+      describe "has_many associations" do
+        subject { associations[:has_many] }
 
-        describe "[:has_many]" do
-          let(:association) do
+        context "single" do
+          let(:comments_association) do
             {
               name: :comments,
               data_key: :user_comments,
@@ -188,21 +170,22 @@ describe Her::Model::Associations do
               inverse_of: :admin
             }
           end
+          before do
+            Foo::User.has_many :comments, class_name: "Post",
+                                          inverse_of: :admin,
+                                          data_key: :user_comments,
+                                          default: {}
+          end
 
-          it { is_expected.to eql [association] }
+          it { is_expected.to eql [comments_association] }
         end
       end
 
-      context "single has_one association" do
-        before do
-          Foo::User.has_one :category, class_name: "Topic",
-                                       foreign_key: "topic_id",
-                                       data_key: :topic, default: nil
-        end
-        subject { super()[:has_one] }
+      describe "has_one associations" do
+        subject { associations[:has_one] }
 
-        describe "[:has_one]" do
-          let(:association) do
+        context "single" do
+          let(:category_association) do
             {
               name: :category,
               data_key: :topic,
@@ -212,22 +195,21 @@ describe Her::Model::Associations do
               path: "/category"
             }
           end
+          before do
+            Foo::User.has_one :category, class_name: "Topic",
+                                         foreign_key: "topic_id",
+                                         data_key: :topic, default: nil
+          end
 
-          it { is_expected.to eql [association] }
+          it { is_expected.to eql [category_association] }
         end
       end
 
-      context "single belongs_to association" do
-        before do
-          Foo::User.belongs_to :organization, class_name: "Business",
-                                              foreign_key: "org_id",
-                                              data_key: :org,
-                                              default: true
-        end
-        subject { super()[:belongs_to] }
+      describe "belongs_to associations" do
+        subject { associations[:belongs_to] }
 
-        describe "[:belongs_to]" do
-          let(:association) do
+        context "single" do
+          let(:organization_association) do
             {
               name: :organization,
               data_key: :org,
@@ -237,8 +219,14 @@ describe Her::Model::Associations do
               path: "/organizations/:id"
             }
           end
+          before do
+            Foo::User.belongs_to :organization, class_name: "Business",
+                                                foreign_key: "org_id",
+                                                data_key: :org,
+                                                default: true
+          end
 
-          it { is_expected.to eql [association] }
+          it { is_expected.to eql [organization_association] }
         end
       end
     end
@@ -247,15 +235,15 @@ describe Her::Model::Associations do
       before { Foo::User.has_many :comments, class_name: "Post" }
 
       describe "associations accessor" do
-        subject { Class.new(Foo::User).associations }
+        subject(:associations) { Class.new(Foo::User).associations }
 
         describe "#object_id" do
-          subject { super().object_id }
+          subject { associations.object_id }
           it { is_expected.not_to eql Foo::User.associations.object_id }
         end
 
         describe "[:has_many]" do
-          subject { super()[:has_many] }
+          subject { associations[:has_many] }
           let(:association) do
             {
               name: :comments,

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -682,14 +682,18 @@ describe Her::Model::Associations do
     end
 
     context "with #build" do
+      let(:comment) { Foo::User.new(id: 10).comments.build(body: "Hello!") }
+
       it "takes the parent primary key" do
-        @comment = Foo::User.new(id: 10).comments.build(body: "Hello!")
-        expect(@comment.body).to eq("Hello!")
-        expect(@comment.user_id).to eq(10)
+        expect(comment.body).to eq("Hello!")
+        expect(comment.user_id).to eq(10)
       end
     end
 
     context "with #create" do
+      let(:user) { Foo::User.find(10) }
+      let(:comment) { user.comments.create(body: "Hello!") }
+
       before do
         Her::API.setup url: "https://api.example.com" do |builder|
           builder.use Her::Middleware::FirstLevelParseJSON
@@ -705,25 +709,30 @@ describe Her::Model::Associations do
       end
 
       it "takes the parent primary key and saves the resource" do
-        @user = Foo::User.find(10)
-        @comment = @user.comments.create(body: "Hello!")
-        expect(@comment.id).to eq(1)
-        expect(@comment.body).to eq("Hello!")
-        expect(@comment.user_id).to eq(10)
-        expect(@user.comments).to eq([@comment])
+        expect(comment.id).to eq(1)
+        expect(comment.body).to eq("Hello!")
+        expect(comment.user_id).to eq(10)
+        expect(user.comments).to eq([comment])
       end
     end
 
     context "with #new" do
-      it "creates nested models from hash attibutes" do
-        user = Foo::User.new(name: "vic", comments: [{ text: "hello" }])
-        expect(user.comments.first.text).to eq("hello")
+      let(:user) { Foo::User.new(name: "vic", comments: [comment]) }
+
+      context "using hash attributes" do
+        let(:comment) { { text: "hello" } }
+
+        it "assigns nested models" do
+          expect(user.comments.first.text).to eq("hello")
+        end
       end
 
-      it "assigns nested models if given as already constructed objects" do
-        bye = Foo::Comment.new(text: "goodbye")
-        user = Foo::User.new(name: "vic", comments: [bye])
-        expect(user.comments.first.text).to eq("goodbye")
+      context "using constructed objects" do
+        let(:comment) { Foo::Comment.new(text: "goodbye") }
+
+        it "assigns nested models" do
+          expect(user.comments.first.text).to eq("goodbye")
+        end
       end
     end
   end


### PR DESCRIPTION
The `spec/model/associations_spec.rb` file has complex test cases and I thought some refactoring would help increase its readability and understanding.

Here you'll find improvements such as:
* Rearrange contexts
* Remove instance variables in favor of `let`
* Prepare data for contexts in a more isolated manner
* Enhance overall readability