### PR TITLE
Fix instance variable naming clash

### DIFF
--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -204,7 +204,7 @@ describe Her::Model::Attributes do
 
         spawn_model "Foo::User" do
           def document
-            @attributes[:document][:url]
+            self.attributes[:document][:url]
           end
         end
       end
@@ -229,7 +229,7 @@ describe Her::Model::Attributes do
 
         spawn_model "Foo::User" do
           def document=(document)
-            @attributes[:document] = document[:url]
+            @_her_attributes[:document] = document[:url]
           end
         end
       end
@@ -288,19 +288,19 @@ describe Her::Model::Attributes do
       it { is_expected.to respond_to(:fullname?) }
     end
 
-    it "defines setter that affects @attributes" do
+    it "defines setter that affects attributes" do
       user = Foo::User.new
       user.fullname = "Tobias Fünke"
       expect(user.attributes[:fullname]).to eq("Tobias Fünke")
     end
 
-    it "defines getter that reads @attributes" do
+    it "defines getter that reads attributes" do
       user = Foo::User.new
       user.assign_attributes(fullname: "Tobias Fünke")
       expect(user.fullname).to eq("Tobias Fünke")
     end
 
-    it "defines predicate that reads @attributes" do
+    it "defines predicate that reads attributes" do
       user = Foo::User.new
       expect(user.fullname?).to be_falsey
       user.assign_attributes(fullname: "Tobias Fünke")
@@ -335,19 +335,19 @@ describe Her::Model::Attributes do
         expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname?)
       end
 
-      it "defines setter that affects @attributes" do
+      it "defines setter that affects attributes" do
         user = Foo::User.new
         user.fullname = "Tobias Fünke"
         expect(user.attributes[:fullname]).to eq("Tobias Fünke")
       end
 
-      it "defines getter that reads @attributes" do
+      it "defines getter that reads attributes" do
         user = Foo::User.new
         user.attributes[:fullname] = "Tobias Fünke"
         expect(user.fullname).to eq("Tobias Fünke")
       end
 
-      it "defines predicate that reads @attributes" do
+      it "defines predicate that reads attributes" do
         user = Foo::User.new
         expect(user.fullname?).to be_falsey
         user.attributes[:fullname] = "Tobias Fünke"

--- a/spec/model/orm_spec.rb
+++ b/spec/model/orm_spec.rb
@@ -172,11 +172,11 @@ describe Her::Model::ORM do
 
         def friends=(val)
           val = val.delete("\r").split("\n").map { |friend| friend.gsub(/^\s*\*\s*/, "") } if val && val.is_a?(String)
-          @attributes[:friends] = val
+          @_her_attributes[:friends] = val
         end
 
         def friends
-          @attributes[:friends].map { |friend| "* #{friend}" }.join("\n")
+          @_her_attributes[:friends].map { |friend| "* #{friend}" }.join("\n")
         end
       end
     end
@@ -185,7 +185,7 @@ describe Her::Model::ORM do
       @user = User.find(1)
       expect(@user.friends).to eq("* Maeby\n* GOB\n* Anne")
       @user.instance_eval do
-        @attributes[:friends] = %w(Maeby GOB Anne)
+        @_her_attributes[:friends] = %w(Maeby GOB Anne)
       end
     end
 
@@ -194,7 +194,7 @@ describe Her::Model::ORM do
       @user.friends = "* George\n* Oscar\n* Lucille"
       expect(@user.friends).to eq("* George\n* Oscar\n* Lucille")
       @user.instance_eval do
-        @attributes[:friends] = %w(George Oscar Lucille)
+        @_her_attributes[:friends] = %w(George Oscar Lucille)
       end
     end
   end


### PR DESCRIPTION
The natural choice of instance variable naming here would be
`@attributes`. Unfortunately that causes a naming clash when
used with `ActiveModel` version >= 5.2.0.
As of v5.2.0 `ActiveModel` checks to see if `ActiveRecord`
attributes exist, assuming that if the instance variable
`@attributes` exists on the instance, it is because they are
`ActiveRecord` attributes.

related to: https://github.com/remiprev/her/pull/492 