### PR TITLE
branch code on changes to activemodel 4.2.1

### DIFF
--- a/her.gemspec
+++ b/her.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "json", "~> 1.8"
 
-  s.add_runtime_dependency "activemodel", ">= 3.0.0", "<= 6.0.0"
-  s.add_runtime_dependency "activesupport", ">= 3.0.0", "<= 6.0.0"
+  s.add_runtime_dependency "activemodel", ">= 3.0.0", "< 5.2.0"
+  s.add_runtime_dependency "activesupport", ">= 3.0.0", "< 5.2.0"
   s.add_runtime_dependency "faraday", ">= 0.8", "< 1.0"
   s.add_runtime_dependency "multi_json", "~> 1.7"
 end


### PR DESCRIPTION
As discussed in #492, some of the changes introduced in activemodel 4.2.1 are backwards incompatible so we need to branch out the codebase like [Devise](https://github.com/plataformatec/devise/branches/all) and prepare for a major `1.0` release. Once this PR is merged we'll need to publish a 0.10.1 release and maintain a [0.x](https://github.com/remiprev/her/tree/0.x) branch.