### PR TITLE
update activemodel dependency to 4.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,39 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.4.2
-  - 2.3.5
-  - 2.2.8
-  - 2.1.6
-  - 2.0.0
   - 1.9.3
+  - 2.0.0
+  - 2.1.6
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 gemfile:
   - gemfiles/Gemfile.activemodel-4.2
-  - gemfiles/Gemfile.activemodel-4.1
-  - gemfiles/Gemfile.activemodel-4.0
-  - gemfiles/Gemfile.activemodel-3.2.x
+  - gemfiles/Gemfile.activemodel-5.0
+  - gemfiles/Gemfile.activemodel-5.1
+  - gemfiles/Gemfile.activemodel-5.2
+
+matrix:
+  exclude:
+    - gemfile: gemfiles/Gemfile.activemodel-5.0
+      rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile.activemodel-5.0
+      rvm: 2.0.0
+    - gemfile: gemfiles/Gemfile.activemodel-5.0
+      rvm: 2.1.6
+    - gemfile: gemfiles/Gemfile.activemodel-5.1
+      rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile.activemodel-5.1
+      rvm: 2.0.0
+    - gemfile: gemfiles/Gemfile.activemodel-5.1
+      rvm: 2.1.6
+    - gemfile: gemfiles/Gemfile.activemodel-5.2
+      rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile.activemodel-5.2
+      rvm: 2.0.0
+    - gemfile: gemfiles/Gemfile.activemodel-5.2
+      rvm: 2.1.6
 
 before_install:
   - gem install bundler

--- a/gemfiles/Gemfile.activemodel-4.2
+++ b/gemfiles/Gemfile.activemodel-4.2
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 gemspec :path => "../"
 
 gem 'activemodel', '~> 4.2.0'
-gem 'activesupport', '~> 4.2.0'
 gem 'faraday', '~> 0.8.9'

--- a/gemfiles/Gemfile.activemodel-5.0
+++ b/gemfiles/Gemfile.activemodel-5.0
@@ -2,6 +2,5 @@ source "https://rubygems.org"
 
 gemspec :path => "../"
 
-gem 'activemodel', '~> 3.2.0'
-gem 'activesupport', '~> 3.2.0'
+gem 'activemodel', '~> 5.0.0'
 gem 'faraday', '~> 0.8.9'

--- a/gemfiles/Gemfile.activemodel-5.1
+++ b/gemfiles/Gemfile.activemodel-5.1
@@ -2,6 +2,5 @@ source "https://rubygems.org"
 
 gemspec :path => "../"
 
-gem 'activemodel', '~> 4.1.0'
-gem 'activesupport', '~> 4.1.0'
+gem 'activemodel', '~> 5.1.0'
 gem 'faraday', '~> 0.8.9'

--- a/gemfiles/Gemfile.activemodel-5.2
+++ b/gemfiles/Gemfile.activemodel-5.2
@@ -2,6 +2,5 @@ source "https://rubygems.org"
 
 gemspec :path => "../"
 
-gem 'activemodel', '~> 4.0.0'
-gem 'activesupport', '~> 4.0.0'
+gem 'activemodel', '~> 5.2.0'
 gem 'faraday', '~> 0.8.9'

--- a/her.gemspec
+++ b/her.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.5"
   s.add_development_dependency "json", "~> 1.8"
 
-  s.add_runtime_dependency "activemodel", ">= 3.0.0", "< 5.2.0"
-  s.add_runtime_dependency "activesupport", ">= 3.0.0", "< 5.2.0"
+  s.add_runtime_dependency "activemodel", ">= 4.2.1"
   s.add_runtime_dependency "faraday", ">= 0.8", "< 1.0"
   s.add_runtime_dependency "multi_json", "~> 1.7"
 end

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -162,7 +162,7 @@ module Her
             attributes = klass.parse(record).merge(_metadata: parsed_data[:metadata],
                                                    _errors: parsed_data[:errors])
             klass.new(attributes).tap do |record|
-              record.instance_variable_set(:@changed_attributes, {})
+              record.send :clear_changes_information
               record.run_callbacks :find
             end
           end

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -44,10 +44,7 @@ module Her
             self.class.request(to_params.merge(:_method => method, :_path => request_path)) do |parsed_data, response|
               load_from_parsed_data(parsed_data)
               return false if !response.success? || @response_errors.any?
-              if self.changed_attributes.present?
-                @previously_changed = self.changes.clone
-                self.changed_attributes.clear
-              end
+              changes_applied
             end
           end
         end

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -354,43 +354,5 @@ describe Her::Model::Attributes do
         expect(user.fullname?).to be_truthy
       end
     end
-
-    if ActiveModel::VERSION::MAJOR < 4
-      it "creates a new mutex" do
-        expect(Mutex).to receive(:new).once.and_call_original
-        spawn_model "Foo::User" do
-          attributes :fullname
-        end
-        expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
-      end
-
-      it "works well with Module#synchronize monkey patched by ActiveSupport" do
-        Module.class_eval do
-          def synchronize(*_args)
-            raise "gotcha!"
-          end
-        end
-        expect(Mutex).to receive(:new).once.and_call_original
-        spawn_model "Foo::User" do
-          attributes :fullname
-        end
-        expect(Foo::User.attribute_methods_mutex).not_to eq(Foo::User.generated_attribute_methods)
-        Module.class_eval do
-          undef :synchronize
-        end
-      end
-    else
-      it "uses ActiveModel's mutex" do
-        expect(Foo::User.attribute_methods_mutex).to eq(Foo::User.generated_attribute_methods)
-      end
-    end
-
-    it "uses a mutex" do
-      spawn_model "Foo::User"
-      expect(Foo::User.attribute_methods_mutex).to receive(:synchronize).once.and_call_original
-      Foo::User.class_eval do
-        attributes :fullname, :documents
-      end
-    end
   end
 end

--- a/spec/model/attributes_spec.rb
+++ b/spec/model/attributes_spec.rb
@@ -310,10 +310,16 @@ describe Her::Model::Attributes do
     context "when attribute methods are already defined" do
       before do
         class AbstractUser
-          attr_accessor :fullname
+          def fullname
+            raise NotImplementedError
+          end
+
+          def fullname=(value)
+            raise NotImplementedError
+          end
 
           def fullname?
-            @fullname.present?
+            raise NotImplementedError
           end
         end
         @spawned_models << :AbstractUser
@@ -324,34 +330,18 @@ describe Her::Model::Attributes do
       end
 
       it "overrides getter method" do
-        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname)
+        user = Foo::User.new
+        expect { user.fullname }.to_not raise_error(NotImplementedError)
       end
 
       it "overrides setter method" do
-        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname=)
+        user = Foo::User.new
+        expect { user.fullname = "foo" }.to_not raise_error(NotImplementedError)
       end
 
       it "overrides predicate method" do
-        expect(Foo::User.generated_attribute_methods.instance_methods).to include(:fullname?)
-      end
-
-      it "defines setter that affects attributes" do
         user = Foo::User.new
-        user.fullname = "Tobias Fünke"
-        expect(user.attributes[:fullname]).to eq("Tobias Fünke")
-      end
-
-      it "defines getter that reads attributes" do
-        user = Foo::User.new
-        user.attributes[:fullname] = "Tobias Fünke"
-        expect(user.fullname).to eq("Tobias Fünke")
-      end
-
-      it "defines predicate that reads attributes" do
-        user = Foo::User.new
-        expect(user.fullname?).to be_falsey
-        user.attributes[:fullname] = "Tobias Fünke"
-        expect(user.fullname?).to be_truthy
+        expect { user.fullname? }.to_not raise_error(NotImplementedError)
       end
     end
   end


### PR DESCRIPTION
Based on #492, some of the changes introduced in activemodel 4.2.1 are backwards incompatible and require a major release of her. This PR updates our dependency to activemodel and refactors some of the code associated with dirty attributes to take advantage of the improved api. It also adds 5.0, 5.1, and 5.2 versions of activemodel to our travis build matrix to validate support.