### PR TITLE
fix path option on belongs_to association

### DIFF
--- a/lib/her/model/associations/belongs_to_association.rb
+++ b/lib/her/model/associations/belongs_to_association.rb
@@ -80,7 +80,7 @@ module Her
           return @parent.attributes[@name] unless @params.any? || @parent.attributes[@name].blank?
 
           path_params = @parent.attributes.merge(@params.merge(@klass.primary_key => foreign_key_value))
-          path = build_association_path -> { @klass.build_request_path(path_params) }
+          path = build_association_path -> { @klass.build_request_path(@opts[:path], path_params) }
           @klass.get_resource(path, @params).tap do |result|
             @cached_result = result if @params.blank?
           end

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -662,8 +662,7 @@ describe Her::Model::Associations do
           builder.adapter :test do |stub|
             stub.get("/users/1") { [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." }, organization_id: 1 }.to_json] }
             stub.get("/users/4") { [200, {}, { id: 1, name: "Tobias Fünke", organization: { id: 1, name: "Bluth Company Inc." } }.to_json] }
-            stub.get("/users/3") { [200, {}, { id: 2, name: "Lindsay Fünke", company: nil }.to_json] }
-            stub.get("/companies/1") { [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
+            stub.get("/users/3") { [200, {}, { id: 2, name: "Lindsay Fünke", organization: nil }.to_json] }
           end
         end
       end
@@ -700,7 +699,7 @@ describe Her::Model::Associations do
           builder.use Faraday::Request::UrlEncoded
           builder.adapter :test do |stub|
             stub.get("/users/2") { [200, {}, { id: 2, name: "Lindsay Fünke", organization_id: 1 }.to_json] }
-            stub.get("/companies/1") { [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
+            stub.get("/organizations/1") { [200, {}, { id: 1, name: "Bluth Company" }.to_json] }
           end
         end
       end


### PR DESCRIPTION
fixes #506 

`path` option was being ignored on `belongs_to` associations and replaced with the default. According to the [documentation](https://www.rubydoc.info/github/remiprev/her/Her%2FModel%2FAssociations%2FClassMethods:belongs_to) 

> Options Hash (opts):
> :path (Path) — The relative path where to fetch the data (defaults to `/class_name.pluralize/id`)

#### Example of the behavior

```ruby
class User
  include Her::Model
  
  belongs_to :company, path: "/organizations/:id", 
                       foreign_key: :organization_id, 
                       data_key: :organization
end


class Company
  include Her::Model
end
```

**Before**

```
> user = User.find(1) 
# GET "/users/1", response is:
# {
#   "id": 1,
#   "name": "George Michael Bluth",
#   "organization_id": 2
# }

> user.company # goes to wrong path
# GET "/companies/2"
```

**After**

```
> user = User.find(1) 
# GET "/users/1", response is:
# {
#   "id": 1,
#   "name": "George Michael Bluth",
#   "organization_id": 2
# }

> user.company # goes to correct path
# GET "/organizations/2"
```