### PR TITLE
Remove unused variable from Model::Http#custom method

### DIFF
--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -97,7 +97,6 @@ module Her
 
             def custom_#{method}(*paths)
               metaclass = (class << self; self; end)
-              opts = paths.last.is_a?(Hash) ? paths.pop : Hash.new
 
               paths.each do |path|
                 metaclass.send(:define_method, path) do |*params|

--- a/lib/her/model/http.rb
+++ b/lib/her/model/http.rb
@@ -98,6 +98,12 @@ module Her
             def custom_#{method}(*paths)
               metaclass = (class << self; self; end)
 
+              # TODO: Remove this check after January 2020
+              if paths.last.is_a?(Hash)
+                warn("[DEPRECATION] options for custom request methods are deprecated and will be removed on or after January 2020.")
+                paths.pop
+              end
+
               paths.each do |path|
                 metaclass.send(:define_method, path) do |*params|
                   params = params.first || Hash.new

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -158,18 +158,16 @@ describe Her::Model::HTTP do
     subject { Foo::User }
 
     describe :custom_get do
-      context "without cache" do
-        before { Foo::User.custom_get :popular, :recent }
-        it { is_expected.to respond_to(:popular) }
-        it { is_expected.to respond_to(:recent) }
+      before { Foo::User.custom_get :popular, :recent }
+      it { is_expected.to respond_to(:popular) }
+      it { is_expected.to respond_to(:recent) }
 
-        context "making the HTTP request" do
-          subject { Foo::User.popular }
+      context "making the HTTP request" do
+        subject { Foo::User.popular }
 
-          describe "#length" do
-            subject { super().length }
-            it { is_expected.to eq(2) }
-          end
+        describe "#length" do
+          subject { super().length }
+          it { is_expected.to eq(2) }
         end
       end
     end

--- a/spec/model/http_spec.rb
+++ b/spec/model/http_spec.rb
@@ -185,5 +185,26 @@ describe Her::Model::HTTP do
         end
       end
     end
+
+    describe "#custom_get with deprecated options" do
+      context "making the HTTP request" do
+        before do
+          allow(Foo::User).to receive(:warn)
+          Foo::User.custom_get :popular, foo: "bar"
+        end
+
+        specify do
+          expect(Foo::User).to have_received(:warn).with(
+            "[DEPRECATION] options for custom request methods are deprecated and will be removed on or after January 2020."
+          )
+        end
+
+        describe "id" do
+          subject { Foo::User.popular.first.id }
+
+          specify { is_expected.to eq(1) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The `opts` variable inside `Http#custom_` was introduced in [88973d7](https://github.com/remiprev/her/commit/88973d7be54de7e7b4c8348609cb567e0ce4f0db#diff-8748e6bfaf520753b590aabc01e77c7aR76) and was overlooked during removing caching functionality in [942a4abd](https://github.com/remiprev/her/commit/942a4abd392ca85e895e8348fdad828b4c37f028#diff-8748e6bfaf520753b590aabc01e77c7aL81).
I got `assigned but unused variable - opts` warning in one of my projects and after checking, discovered that the variable could be indeed removed.