### PR TITLE
Fix typos

### DIFF
--- a/lib/her/model/base.rb
+++ b/lib/her/model/base.rb
@@ -1,6 +1,6 @@
 module Her
   module Model
-    # This module includes basic functionnality to Her::Model
+    # This module includes basic functionality to Her::Model
     module Base
       extend ActiveSupport::Concern
 
@@ -16,7 +16,7 @@ module Her
 
       # Returns
       # * the value of the attribute_name attribute if it's in orm data
-      # * the resource/collection corrsponding to attribute_name if it's an association
+      # * the resource/collection corresponding to attribute_name if it's an association
       #
       # @private
       def [](attribute_name)

--- a/lib/her/model/orm.rb
+++ b/lib/her/model/orm.rb
@@ -105,7 +105,7 @@ module Her
         self
       end
 
-      # Initializes +attribute+ to zero if +nil+ and substracts the value passed as
+      # Initializes +attribute+ to zero if +nil+ and subtracts the value passed as
       # +by+ (default is 1). The decrement is performed directly on the
       # underlying attribute, no setter is invoked. Only makes sense for
       # number-based attributes. Returns +self+.

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -42,7 +42,7 @@ module Her
             memo[key.to_sym] = value
           end
 
-          filtered_attributes.merge!(embeded_params(attributes))
+          filtered_attributes.merge!(embedded_params(attributes))
 
           if her_api.options[:send_only_modified_attributes]
             filtered_attributes.slice! *changes.keys.map(&:to_sym)
@@ -60,7 +60,7 @@ module Her
         end
 
         # @private
-        def embeded_params(attributes)
+        def embedded_params(attributes)
           associations.values.flatten.each_with_object({}) do |definition, hash|
             value = case association = attributes[definition[:name]]
                     when Her::Collection, Array

--- a/spec/model/relation_spec.rb
+++ b/spec/model/relation_spec.rb
@@ -31,7 +31,7 @@ describe Her::Model::Relation do
         spawn_model "Foo::User"
       end
 
-      it "doesn't fetch the data immediatly" do
+      it "doesn't fetch the data immediately" do
         expect(Foo::User).to receive(:request).never
         @users = Foo::User.where(admin: 1)
       end


### PR DESCRIPTION
Found via `codespell -H` and `typos --format brief`